### PR TITLE
feat: add working-directory input to call-ko-build

### DIFF
--- a/.github/workflows/call-ko-build.yaml
+++ b/.github/workflows/call-ko-build.yaml
@@ -16,6 +16,10 @@ on:
         default: "."
         type: string
         description: "Ko importpath to build (e.g. ./cmd/myapp)"
+      working-directory:
+        default: "."
+        type: string
+        description: "Directory containing go.mod (for mono-repos)"
 permissions:
   contents: read
   packages: write
@@ -53,6 +57,7 @@ jobs:
           echo "version=$(git describe --tags --always 2>/dev/null || echo unset)" >> $GITHUB_OUTPUT
 
       - name: Build and push image
+        working-directory: ${{ inputs.working-directory }}
         run: |
           ko build --bare --tags=${{ steps.image-repo.outputs.tag }} ${{ inputs.build-path }} \
             --platform=${{ inputs.platforms }}


### PR DESCRIPTION
## Summary
- Adds `working-directory` input (default: `.`) to `call-ko-build.yaml`
- Needed for mono-repos where `go.mod` is in a subdirectory (e.g. `golden-image-workflow/`)
- Without this, `ko build` fails with `cannot find main module`

## Test plan
- [ ] Verify with `dapr-workflows` repo (uses `working-directory: golden-image-workflow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)