### PR TITLE
fix: add cache-dependency-path for mono-repo support

### DIFF
--- a/.github/workflows/call-ko-build.yaml
+++ b/.github/workflows/call-ko-build.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go-version }}
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
 
       - name: Set up Ko
         uses: ko-build/setup-ko@v0.9


### PR DESCRIPTION
## Summary
- `setup-go` fails cache restore when `go.mod` is not at repo root
- Adds `cache-dependency-path: working-directory/go.sum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)