### PR TITLE
fix(call-stage-image): pass username as literal string

### DIFF
--- a/.github/workflows/call-stage-image.yaml
+++ b/.github/workflows/call-stage-image.yaml
@@ -53,12 +53,11 @@ jobs:
             --source ${{ inputs.source-image }}
             --target ${{ inputs.target-image }}
             --target-registry ${{ inputs.target-registry }}
-            --target-username env:REGISTRY_USERNAME
+            --target-username ${{ github.actor }}
             --target-password env:REGISTRY_PASSWORD
             --platform ${{ inputs.platform }}
           cloud-token: ${{ secrets.dagger-cloud-token }}
         env:
-          REGISTRY_USERNAME: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary


### PR DESCRIPTION
## Summary
Dagger's \`env:\` prefix only resolves env vars for **Secret**-typed args. The crane module's \`target-username\` is a plain \`string\`, so passing \`env:REGISTRY_USERNAME\` sent that literal value and ghcr denied the auth. Substitute \`github.actor\` directly in YAML; keep \`env:\` for the password Secret.

## Verification
- Probed the same GITHUB_TOKEN with curl against \`ghcr.io/token?scope=…:push,pull\` → HTTP 200.
- Dagger copy call failed with \`DENIED: denied\` using \`env:REGISTRY_USERNAME\`.
- After this fix, the same call succeeds end-to-end copying \`ttl.sh/stuttgart-things-sthings-backstage:<sha>\` to \`ghcr.io/stuttgart-things/sthings-backstage:stage\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)