### PR TITLE
feat(workflows): add call-validate-json-schema reusable workflow

### DIFF
--- a/.github/workflows/call-validate-json-schema.yaml
+++ b/.github/workflows/call-validate-json-schema.yaml
@@ -1,0 +1,59 @@
+---
+name: Validate JSON Schema with Dagger
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: dagger-labda
+      environment-name:
+        required: false
+        type: string
+        default: k8s
+      src:
+        description: "Directory to scan (relative to repo root)"
+        required: false
+        type: string
+        default: "."
+      glob:
+        description: "Basename glob passed to the Dagger module (default **/*.schema.json)"
+        required: false
+        type: string
+        default: ""
+      dagger-version:
+        description: "Dagger CLI version"
+        required: false
+        type: string
+        default: "0.20.6"
+      linting-module-version:
+        description: "Version of stuttgart-things/dagger/linting to invoke"
+        required: false
+        type: string
+        default: v0.100.0
+
+permissions:
+  contents: read
+
+jobs:
+  Validate-Json-Schema:
+    name: Validate JSON Schema (${{ inputs.src }})
+    runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment-name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate JSON Schema
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: ${{ inputs.dagger-version }}
+          verb: call
+          module: github.com/stuttgart-things/dagger/linting@${{ inputs.linting-module-version }}
+          args: >-
+            validate-json-schema
+            --src ${{ inputs.src }}
+            ${{ inputs.glob != '' && format('--glob {0}', inputs.glob) || '' }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
## Summary
- New reusable workflow `call-validate-json-schema.yaml` wrapping `stuttgart-things/dagger/linting` `validate-json-schema`
- Mirrors `call-helm-verify.yaml` shape (inputs for `runs-on`, `environment-name`, `dagger-version`, module version; `cloud-token` via secrets)
- Exposes `src` (default `.`) and optional `glob` to override the module default (`**/*.schema.json`)
- Default linting module pin: `v0.100.0`

## Test plan
- [ ] Consumer repo (stuttgart-things/argocd) pins `@main` and runs green against its `values.schema.json` files
- [ ] Workflow YAML parses in GitHub Actions (no startup error)
- [ ] Overriding `glob` with a non-matching pattern exits 0 (Dagger module prints "no files matched")

🤖 Generated with [Claude Code](https://claude.com/claude-code)