### PR TITLE
fix(call-argocd-verify-catalog): default runner to ubuntu-latest, bump module to v0.104.0

### DIFF
--- a/.github/workflows/call-argocd-verify-catalog.yaml
+++ b/.github/workflows/call-argocd-verify-catalog.yaml
@@ -6,7 +6,7 @@ on:
       runs-on:
         required: false
         type: string
-        default: dagger-labda
+        default: ubuntu-latest
       environment-name:
         required: false
         type: string
@@ -32,7 +32,7 @@ on:
         description: "Version of stuttgart-things/dagger/argocd to invoke"
         required: false
         type: string
-        default: v0.102.0
+        default: v0.104.0
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Switch default `runs-on` from self-hosted `dagger-labda` to `ubuntu-latest` so the reusable workflow works for consumers without that runner pool.
- Bump default `argocd-module-version` from `v0.102.0` to `v0.104.0` — the release that adds `helm.Lint` per chart and the argocd#41 double-render regression guard inside `argocd.VerifyCatalog`.

## Test plan
- [ ] Consumer workflow in `stuttgart-things/argocd` runs green on `ubuntu-latest` with the bumped module.
- [ ] Self-hosted users can still override via `with: runs-on: dagger-labda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)