### PR TITLE
feat(workflows): GHCR + PR-tagged kustomize/image artifacts (#77)

### DIFF
--- a/.github/workflows/call-cleanup-pr-artifacts.yaml
+++ b/.github/workflows/call-cleanup-pr-artifacts.yaml
@@ -1,0 +1,93 @@
+---
+name: Cleanup PR-tagged GHCR Artifacts
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        default: ubuntu-latest
+        type: string
+      packages:
+        required: true
+        type: string
+        description: |
+          Newline- or comma-separated list of GHCR package names to clean,
+          e.g. "myrepo,myrepo-kustomize". Owner is taken from github.repository_owner.
+      package-type:
+        default: container
+        type: string
+        description: "GHCR package type (container | maven | npm | rubygems | nuget)"
+      tag-pattern:
+        default: 'pr-${{ github.event.number }}-'
+        type: string
+        description: |
+          Tag prefix to delete. Default deletes all versions whose tags start
+          with `pr-<num>-` for the closed PR. Override for custom schemes.
+      dry-run:
+        default: false
+        type: boolean
+        description: "List matching versions without deleting"
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Delete PR-tagged versions
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Delete versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGES: ${{ inputs.packages }}
+          PACKAGE_TYPE: ${{ inputs.package-type }}
+          TAG_PATTERN: ${{ inputs.tag-pattern }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          PKGS=$(echo "$PACKAGES" | tr ',\n' ' ')
+          for PKG in $PKGS; do
+            [ -z "$PKG" ] && continue
+            echo "::group::Package ${PKG}"
+
+            # GHCR uses URL-encoded slashes for package names with paths
+            ENCODED=$(echo "$PKG" | sed 's|/|%2F|g')
+            API="/orgs/${OWNER}/packages/${PACKAGE_TYPE}/${ENCODED}/versions"
+
+            # Fall back to user-scoped API if org call 404s
+            if ! gh api "$API" --paginate >/tmp/versions.json 2>/dev/null; then
+              API="/users/${OWNER}/packages/${PACKAGE_TYPE}/${ENCODED}/versions"
+              gh api "$API" --paginate >/tmp/versions.json
+            fi
+
+            MATCHED=$(jq -r --arg p "$TAG_PATTERN" \
+              '.[] | select(.metadata.container.tags // [] | any(startswith($p))) | "\(.id)\t\(.metadata.container.tags | join(","))"' \
+              /tmp/versions.json)
+
+            if [ -z "$MATCHED" ]; then
+              echo "No versions match pattern: ${TAG_PATTERN}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "$MATCHED" | while IFS=$'\t' read -r ID TAGS; do
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "[dry-run] would delete version ${ID} (tags: ${TAGS})"
+              else
+                echo "Deleting version ${ID} (tags: ${TAGS})"
+                gh api -X DELETE "${API}/${ID}"
+              fi
+            done
+
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        run: |
+          {
+            echo "## PR Artifact Cleanup"
+            echo ""
+            echo "**Packages:** \`${{ inputs.packages }}\`"
+            echo "**Tag pattern:** \`${{ inputs.tag-pattern }}\`"
+            echo "**Dry run:** \`${{ inputs.dry-run }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/call-ko-build.yaml
+++ b/.github/workflows/call-ko-build.yaml
@@ -20,6 +20,29 @@ on:
         default: "."
         type: string
         description: "Directory containing go.mod (for mono-repos)"
+      registry:
+        default: ttl.sh
+        type: string
+        description: "Target registry: ttl.sh (ephemeral, default) or ghcr.io"
+      image-repo:
+        default: ""
+        type: string
+        description: |
+          Image repo path under the registry. For ghcr.io defaults to
+          <owner>/<repo>; for ttl.sh defaults to <repo>-<random6hex>.
+      tags:
+        default: latest
+        type: string
+        description: "Comma-separated tags to push (e.g. pr-42-abc1234,latest)"
+      push:
+        default: true
+        type: boolean
+        description: "Push the image (false = build only, useful for forks)"
+    outputs:
+      image-ref:
+        description: "Fully-qualified pushed image reference (repo:firsttag)"
+        value: ${{ jobs.build.outputs.image-ref }}
+
 permissions:
   contents: read
   packages: write
@@ -28,6 +51,8 @@ jobs:
   build:
     name: Build, Scan & Push Image
     runs-on: ${{ inputs.runs-on }}
+    outputs:
+      image-ref: ${{ steps.image-repo.outputs.image-ref }}
 
     steps:
       - name: Checkout
@@ -42,13 +67,33 @@ jobs:
       - name: Set up Ko
         uses: ko-build/setup-ko@v0.9
 
+      - name: Login to GHCR
+        if: inputs.registry == 'ghcr.io' && inputs.push
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | ko login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Set image repository
         id: image-repo
         run: |
-          REPO_NAME="${{ github.event.repository.name }}"
-          RANDOM_TAG=$(openssl rand -hex 6)
-          echo "repo=ttl.sh/${REPO_NAME}-${RANDOM_TAG}" >> $GITHUB_OUTPUT
-          echo "tag=latest" >> $GITHUB_OUTPUT
+          REGISTRY="${{ inputs.registry }}"
+          IMAGE_REPO="${{ inputs.image-repo }}"
+          TAGS="${{ inputs.tags }}"
+
+          if [ "$REGISTRY" = "ttl.sh" ]; then
+            if [ -z "$IMAGE_REPO" ]; then
+              IMAGE_REPO="${{ github.event.repository.name }}-$(openssl rand -hex 6)"
+            fi
+          else
+            if [ -z "$IMAGE_REPO" ]; then
+              IMAGE_REPO="${{ github.repository }}"
+            fi
+          fi
+
+          REPO="${REGISTRY}/${IMAGE_REPO}"
+          FIRST_TAG="${TAGS%%,*}"
+
+          echo "repo=${REPO}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "image-ref=${REPO}:${FIRST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Set build metadata
         id: build-meta
@@ -60,8 +105,11 @@ jobs:
       - name: Build and push image
         working-directory: ${{ inputs.working-directory }}
         run: |
-          ko build --bare --tags=${{ steps.image-repo.outputs.tag }} ${{ inputs.build-path }} \
-            --platform=${{ inputs.platforms }}
+          ko build --bare \
+            --tags=${{ steps.image-repo.outputs.tags }} \
+            --push=${{ inputs.push }} \
+            --platform=${{ inputs.platforms }} \
+            ${{ inputs.build-path }}
         env:
           KO_DOCKER_REPO: ${{ steps.image-repo.outputs.repo }}
           VERSION: ${{ steps.build-meta.outputs.version }}
@@ -70,14 +118,17 @@ jobs:
 
       - name: Image Summary
         run: |
-          IMAGE="${{ steps.image-repo.outputs.repo }}:${{ steps.image-repo.outputs.tag }}"
+          IMAGE="${{ steps.image-repo.outputs.image-ref }}"
           echo "## Container Image Build Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:** \`${{ steps.image-repo.outputs.tags }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${IMAGE}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Note:** ttl.sh images expire after 1 hour" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.registry }}" = "ttl.sh" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Note:** ttl.sh images expire after 1 hour" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/call-push-kustomize.yaml
+++ b/.github/workflows/call-push-kustomize.yaml
@@ -1,0 +1,83 @@
+---
+name: Push Kustomize OCI Base
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        default: ubuntu-latest
+        type: string
+      kcl-source-dir:
+        default: kcl
+        type: string
+        description: "KCL source directory (passed as --source)"
+      kcl-profile-file:
+        default: tests/kcl-deploy-profile.yaml
+        type: string
+        description: "KCL profile file (passed as --parameters-file)"
+      kustomize-oci-repo:
+        required: true
+        type: string
+        description: "OCI repo to push, e.g. ghcr.io/<org>/<repo>-kustomize"
+      tag:
+        required: true
+        type: string
+        description: "Tag to push, e.g. pr-42-abc1234 or v1.2.3"
+      dagger-kcl-module:
+        default: github.com/stuttgart-things/dagger/kcl@v0.103.0
+        type: string
+      dagger-version:
+        default: "0.20.6"
+        type: string
+    outputs:
+      artifact-ref:
+        description: "Fully-qualified pushed kustomize OCI artifact reference"
+        value: ${{ jobs.push.outputs.artifact-ref }}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  push:
+    name: Push kustomize base via Dagger
+    runs-on: ${{ inputs.runs-on }}
+    outputs:
+      artifact-ref: ${{ steps.ref.outputs.artifact-ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Push kustomize base
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: ${{ inputs.dagger-version }}
+          module: ${{ inputs.dagger-kcl-module }}
+          call: >-
+            push-kustomize-base
+            --source ./${{ inputs.kcl-source-dir }}
+            --parameters-file ./${{ inputs.kcl-profile-file }}
+            --address ${{ inputs.kustomize-oci-repo }}
+            --tag ${{ inputs.tag }}
+            --user env:GITHUB_USER
+            --password env:GITHUB_TOKEN
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve artifact ref
+        id: ref
+        run: |
+          REF="${{ inputs.kustomize-oci-repo }}:${{ inputs.tag }}"
+          echo "artifact-ref=${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Kustomize OCI Push"
+            echo ""
+            echo "**Artifact:** \`${{ steps.ref.outputs.artifact-ref }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,76 @@ jobs:
 
 </details>
 
+<details><summary>KO BUILD (ttl.sh / ghcr.io)</summary>
+
+```yaml
+jobs:
+  build-image:
+    name: Build & Push Image
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      registry: ghcr.io
+      image-repo: ${{ github.repository }}
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+      push: true
+      build-path: ./cmd/myapp
+    secrets: inherit
+```
+
+Defaults to `registry: ttl.sh` with a random repo + `tag=latest` for throwaway smoke runs.
+When `registry: ghcr.io` the workflow uses `GITHUB_TOKEN` to log in (caller must declare
+`packages: write`). The first tag is exposed as the `image-ref` workflow output for
+downstream scan/deploy/PR-comment jobs.
+
+</details>
+
+<details><summary>PUSH KUSTOMIZE OCI BASE</summary>
+
+```yaml
+jobs:
+  push-kustomize:
+    name: Push Kustomize OCI Base
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/${{ github.repository }}-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit
+```
+
+Wraps `dagger call -m <kcl-module> push-kustomize-base` for callers that need a
+PR-coordinated kustomize artifact on every push (the release-only path lives in
+`call-go-release.yaml`). The pushed `address:tag` is exposed as the `artifact-ref`
+workflow output.
+
+</details>
+
+<details><summary>CLEANUP PR-TAGGED GHCR ARTIFACTS</summary>
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Delete PR-tagged GHCR versions
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      packages: |
+        myrepo
+        myrepo-kustomize
+    secrets: inherit
+```
+
+Defaults to deleting every GHCR version whose tag starts with `pr-<num>-` for the
+closed PR. Set `dry-run: true` first to preview matches. Override `tag-pattern`
+for custom tagging schemes. GHCR retains PR-tagged versions forever otherwise,
+so wire this up alongside any workflow that pushes `pr-<num>-<sha>` artifacts.
+
+</details>
+
 <details><summary>YAML LINT</summary>
 
 ```yaml


### PR DESCRIPTION
Closes #77 (in-repo gaps; pilot consumer migration in `homerun2-omni-pitcher` is a separate PR).

## Summary
- **`call-ko-build.yaml`**: adds `registry` / `image-repo` / `tags` / `push` inputs, GHCR login when `registry: ghcr.io`, and `image-ref` workflow output. `ttl.sh` remains the default so existing callers are unchanged.
- **`call-push-kustomize.yaml`** (new): wraps `dagger call -m <kcl-module> push-kustomize-base` for per-PR kustomize OCI pushes. The release-only path stays in `call-go-release.yaml`. Exposes `artifact-ref` output.
- **`call-cleanup-pr-artifacts.yaml`** (new): sibling cleanup workflow (the issue's preferred option). Deletes GHCR versions whose tag starts with `pr-<num>-` for the closed PR; supports `dry-run` and a custom `tag-pattern`. Falls back from org- to user-scoped GHCR API.
- **`README.md`**: usage blocks for all three workflows, including the cleanup recommendation.

## Acceptance checklist (from #77)
- [x] `call-ko-build.yaml` accepts `registry`, `image-repo`, `tags`, `push` inputs; ghcr mode logs in and pushes; ttl.sh mode unchanged
- [x] Image ref exposed as workflow output
- [x] New `call-push-kustomize.yaml` reusable workflow lands and is callable from a `pull_request` job
- [x] Cleanup story decided (sibling workflow `call-cleanup-pr-artifacts.yaml`) and documented in README
- [ ] `homerun2-omni-pitcher` migrated as pilot consumer — separate PR in that repo

## Test plan
- [ ] Smoke: existing `ttl.sh` callers continue to publish with random tag (no regression)
- [ ] GHCR: caller passes `registry: ghcr.io`, `tags: pr-<num>-<sha>` and downstream job consumes `image-ref` output
- [ ] Kustomize: `call-push-kustomize` pushes `<repo>-kustomize:pr-<num>-<sha>` to GHCR using `GITHUB_TOKEN`
- [ ] Cleanup: PR-close run with `dry-run: true` lists matching versions; production run deletes them; non-matching tags are left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)