### PR TITLE
fix(workflows): bump argocd-bootstrap defaults to blueprints v2.1.4

### DIFF
--- a/.github/workflows/call-argocd-bootstrap.yaml
+++ b/.github/workflows/call-argocd-bootstrap.yaml
@@ -191,17 +191,17 @@ on:
       dagger-version:
         required: false
         type: string
-        default: "0.20.6"
+        default: "0.20.8"
       argocd-module-version:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false
         type: string
-        default: v2.1.3
+        default: v2.1.4
       sops-module-version:
         description: "Version of stuttgart-things/dagger/sops (for kubeconfig decrypt step)"
         required: false
         type: string
-        default: v0.110.0
+        default: v0.112.0
 
 permissions:
   contents: read

--- a/.github/workflows/call-argocd-verify-catalog.yaml
+++ b/.github/workflows/call-argocd-verify-catalog.yaml
@@ -27,7 +27,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.6"
+        default: "0.20.8"
       argocd-module-version:
         description: "Version of stuttgart-things/dagger/argocd to invoke"
         required: false


### PR DESCRIPTION
## Summary

Bumps default versions in two reusable workflows:

**`call-argocd-bootstrap.yaml`**
- `argocd-module-version` `v2.1.0` → `v2.1.4`
- `dagger-version` `0.20.6` → `0.20.8`
- `sops-module-version` `v0.110.0` → `v0.112.0`

**`call-argocd-verify-catalog.yaml`**
- `dagger-version` `0.20.6` → `0.20.8`

## Why

Without bumping `argocd-module-version` to v2.1.4, every consumer of `pr-argocd-bootstrap` that doesn't explicitly override (e.g. `stuttgart-things/stuttgart-things/.github/workflows/pr-argocd-bootstrap.yaml`) continues pulling `blueprints/argocd@v2.1.0` and **still trips the `addFolderToGithubBranch` cache trap** (stuttgart-things/blueprints#158, fixed upstream in stuttgart-things/dagger#267 and shipped in blueprints v2.1.4).

The `dagger-version` and `sops-module-version` bumps come along for consistency: blueprints v2.1.4 was built and `dagger develop`-regenerated against engine v0.20.8 (per stuttgart-things/dagger v0.112.0's engine alignment), and the SOPS module shares that release.

## Scope

- Only the two argocd-related workflows. Older blueprints pins in `call-flux-bootstrap` (v1.85.0), `call-flux-destroy` (v1.70.0), and `call-terraform-vault` (v1.82.0) cross the v1.x → v2.x breaking-change boundary and are intentionally **out of scope** here. Track separately if/when those need attention.
- `call-argocd-verify-catalog`'s `argocd-module-version` (`v0.104.0`, points at `dagger/argocd` not `blueprints/argocd`) is also out of scope — different module, no cache-trap implication.

## Test plan

- [ ] `pr-argocd-bootstrap` in `stuttgart-things/stuttgart-things` (which calls `call-argocd-bootstrap.yaml@main` without overriding `argocd-module-version`) picks up v2.1.4 on the next run.
- [ ] Two consecutive `argocd/bootstrap-clusterbook-cluster` runs on one runner with a fresh `origin/main` commit between them — both succeed without manual `dagger core engine local-cache prune`.
- [ ] Dagger Cloud trace shows `gh repo clone` + `git fetch` no longer marked CACHED on the second run.

Refs stuttgart-things/blueprints#158, stuttgart-things/dagger#267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)