### PR TITLE
fix(workflows): bump call-argocd-bootstrap default argocd-module-version to v2.2.0

### DIFF
--- a/.github/workflows/call-argocd-bootstrap.yaml
+++ b/.github/workflows/call-argocd-bootstrap.yaml
@@ -196,7 +196,7 @@ on:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false
         type: string
-        default: v2.1.4
+        default: v2.2.0
       sops-module-version:
         description: "Version of stuttgart-things/dagger/sops (for kubeconfig decrypt step)"
         required: false


### PR DESCRIPTION
## Summary

One-line bump in `.github/workflows/call-argocd-bootstrap.yaml`:

```diff
- default: v2.1.4
+ default: v2.2.0
```

## Why

`stuttgart-things/blueprints` v2.2.0 ships the new `argocd.create-vault-issuer` function (closes blueprints#162) — provisions cert-manager's vault-pki ClusterIssuer prerequisites on a downstream cluster (Namespace + 2 Secrets) so the existing `cert-manager-vault-pki` AppSet can stand up the ClusterIssuer.

Without bumping the default here, every consumer of `pr-argocd-bootstrap` that doesn't explicitly override (e.g. `stuttgart-things/stuttgart-things/.github/workflows/pr-argocd-bootstrap.yaml`) keeps pulling v2.1.4 and the new function is invisible — same shape as the v2.1.4 bump in #81.

## Scope

- Only `argocd-module-version`. `dagger-version` (0.20.8) and `sops-module-version` (v0.112.0) untouched: dagger v0.112.1 only modified the kubernetes sub-module, the sops module is byte-identical to v0.112.0.
- Other reusable workflows (`call-flux-*`, `call-terraform-vault`, `call-argocd-verify-catalog`) intentionally out of scope — their pins point at unrelated dagger sub-modules / older blueprints versions.

## Test plan

- [ ] Next `pr-argocd-bootstrap` run on `stuttgart-things` resolves to v2.2.0 (visible as `MODULE="github.com/stuttgart-things/blueprints/argocd@v2.2.0"` in the bootstrap step's logs).
- [ ] When the eventual workflow change adds a `--call create-vault-issuer …` step, it succeeds end-to-end (verified locally already against the kind dev1 cluster + infra-sthings Vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)