### PR TITLE
fix(workflows): bump call-argocd-bootstrap default argocd-module-version to v2.2.1

### DIFF
--- a/.github/workflows/call-argocd-bootstrap.yaml
+++ b/.github/workflows/call-argocd-bootstrap.yaml
@@ -196,7 +196,7 @@ on:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false
         type: string
-        default: v2.2.0
+        default: v2.2.1
       sops-module-version:
         description: "Version of stuttgart-things/dagger/sops (for kubeconfig decrypt step)"
         required: false


### PR DESCRIPTION
## Summary

One-line bump:

\`\`\`diff
- default: v2.2.0
+ default: v2.2.1
\`\`\`

## Why

\`stuttgart-things/blueprints\` v2.2.1 (PR #167) fixes \`argocd.create-vault-issuer\`'s env file schema: camelCase keys (\`vaultAddr\`/\`vaultToken\`/\`vaultSkipVerify\`) + optional \`vaultCaBundle\` field, matching how the real per-lab sops env files (e.g. \`secrets/envs/vault-infra-labul.enc.yaml\`) are structured. v2.2.0's snake_case schema doesn't parse those files.

Without this bump, every consumer of \`pr-argocd-bootstrap\` that doesn't override would call into v2.2.0 and trip an immediate parse error on first vault-issuer use.

## Scope

- Same shape as #82 (which bumped v2.1.4 → v2.2.0).
- Only \`argocd-module-version\`. \`dagger-version\` (0.20.8) and \`sops-module-version\` (v0.112.0) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)