### PR TITLE
feat(argocd): wire --cache-buster through bootstrap + vault-issuer call sites

### DIFF
--- a/.github/workflows/call-argocd-bootstrap.yaml
+++ b/.github/workflows/call-argocd-bootstrap.yaml
@@ -196,7 +196,7 @@ on:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false
         type: string
-        default: v2.2.1
+        default: v2.3.1
       sops-module-version:
         description: "Version of stuttgart-things/dagger/sops (for kubeconfig decrypt step)"
         required: false
@@ -307,6 +307,12 @@ jobs:
             [[ -n "${{ inputs.pr-body }}" ]] && ARGS+=(--pr-body "${{ inputs.pr-body }}")
             ARGS+=(--merge-method "${{ inputs.merge-method }}")
           fi
+
+          # Force a fresh function-level cache key per run. Without this,
+          # Dagger short-circuits the whole bootstrap function on input-hash
+          # match and the inner `gh repo clone` + `git push` side effects
+          # never replay — see stuttgart-things/blueprints#168.
+          ARGS+=(--cache-buster "$(date +%s%N)")
 
           MODULE="github.com/stuttgart-things/blueprints/argocd@${{ inputs.argocd-module-version }}"
           echo "Running: dagger call -m $MODULE ${ARGS[*]} export --path ${{ inputs.output-path }}"

--- a/.github/workflows/call-create-vault-issuer.yaml
+++ b/.github/workflows/call-create-vault-issuer.yaml
@@ -77,7 +77,7 @@ on:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false
         type: string
-        default: v2.2.1
+        default: v2.3.1
 
 permissions:
   contents: read
@@ -115,4 +115,5 @@ jobs:
             --token-secret-name ${{ inputs.token-secret-name }}
             --ca-secret-name ${{ inputs.ca-secret-name }}
             --token-ttl ${{ inputs.token-ttl }}
+            --cache-buster ${{ github.run_id }}-${{ github.run_attempt }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
## Summary
- Pins both `call-argocd-bootstrap.yaml` and `call-create-vault-issuer.yaml` to `blueprints/argocd@v2.3.1`
- Threads a fresh `--cache-buster` value into each side-effecting Dagger function call so the function-level cache no longer swallows side-effect replays

## Why
Witnessed in [stuttgart-things/stuttgart-things#2169](https://github.com/stuttgart-things/stuttgart-things/pull/2169): Dagger short-circuited `bootstrapClusterbookCluster` on input-hash match between two independent registrations (`CACHED [0.8s]` in trace), so the rendered cluster.yaml + kubeconfig.yaml never reached the PR branch and [#2170](https://github.com/stuttgart-things/stuttgart-things/pull/2170) had to restore them by hand. Same trap applies to `createVaultIssuer` (vault token mint + kubectl apply).

The blueprints-side fix shipped in v2.3.0 ([blueprints#169](https://github.com/stuttgart-things/blueprints/pull/169)) added a `cacheBuster` input arg; this PR wires it through both reusable workflows.

## Two different cache-buster strategies, same effect
- **`call-argocd-bootstrap.yaml`** builds args in a bash `ARGS=()` array → uses `$(date +%s%N)` directly:
  ```bash
  ARGS+=(--cache-buster "$(date +%s%N)")
  ```
- **`call-create-vault-issuer.yaml`** uses `dagger-for-github`'s `args: >-` literal which isn't bash-expanded → uses the GitHub expression:
  ```yaml
  --cache-buster ${{ github.run_id }}-${{ github.run_attempt }}
  ```
  `run_id` is unique per workflow run, `run_attempt` covers manual retries.

## Test plan
- [ ] Re-register a cluster twice in a row (decom + re-add via Backstage). Bootstrap step's `commit-back` must fire on both runs — trace shows no `CACHED` on the function call.
- [ ] Create-Vault-Issuer step applies fresh Vault token + CA Secret on each run rather than returning the cached output of a previous identical-input call.

Closes stuttgart-things/blueprints#168

🤖 Generated with [Claude Code](https://claude.com/claude-code)