### PR TITLE
feat(workflows): add call-comment-preview-url reusable

### DIFF
--- a/.github/workflows/call-comment-preview-url.yaml
+++ b/.github/workflows/call-comment-preview-url.yaml
@@ -1,0 +1,105 @@
+---
+name: Comment Preview URL on PR
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        default: ubuntu-latest
+        type: string
+      hostname-prefix:
+        required: true
+        type: string
+        description: |
+          Hostname prefix per PR, before `-<num>`. The full URL becomes
+          `https://<hostname-prefix>-<num>.<hostname-domain>`. Example: `omni-pr`, `cc-pr`, `scout-pr`.
+      hostname-domain:
+        required: true
+        type: string
+        description: |
+          Domain suffix appended after `<hostname-prefix>-<num>`. Example:
+          `homerun2-dev.sthings-vsphere.labul.sva.de`.
+      namespace-prefix:
+        required: true
+        type: string
+        description: |
+          Kubernetes namespace prefix per PR, before `-<num>`. Example:
+          `homerun2-pr`, `homerun2-core-catcher-pr`, `homerun2-scout-pr`.
+      argocd-app-prefix:
+        default: ""
+        type: string
+        description: |
+          ArgoCD parent Application name prefix per PR, before `-<num>`.
+          Defaults to `namespace-prefix` when empty.
+      argocd-base-url:
+        default: argocd.platform.sthings-vsphere.labul.sva.de
+        type: string
+        description: "Base hostname of the ArgoCD UI (no scheme)."
+      health-path:
+        default: /health
+        type: string
+        description: "Service health endpoint path appended to the preview URL."
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          HOSTNAME_PREFIX: ${{ inputs.hostname-prefix }}
+          HOSTNAME_DOMAIN: ${{ inputs.hostname-domain }}
+          NAMESPACE_PREFIX: ${{ inputs.namespace-prefix }}
+          ARGOCD_APP_PREFIX: ${{ inputs.argocd-app-prefix }}
+          ARGOCD_BASE_URL: ${{ inputs.argocd-base-url }}
+          HEALTH_PATH: ${{ inputs.health-path }}
+        with:
+          script: |
+            const num = context.issue.number;
+            const {
+              HOSTNAME_PREFIX, HOSTNAME_DOMAIN, NAMESPACE_PREFIX,
+              ARGOCD_APP_PREFIX, ARGOCD_BASE_URL, HEALTH_PATH,
+            } = process.env;
+            const appPrefix = ARGOCD_APP_PREFIX || NAMESPACE_PREFIX;
+            const url = `https://${HOSTNAME_PREFIX}-${num}.${HOSTNAME_DOMAIN}`;
+            const ns = `${NAMESPACE_PREFIX}-${num}`;
+            const app = `${appPrefix}-${num}`;
+            const argo = `https://${ARGOCD_BASE_URL}/applications?search=${app}`;
+            const marker = "<!-- preview-url-bot -->";
+            const body = [
+              marker,
+              "## 🚀 Preview environment",
+              "",
+              `| | |`,
+              `|--|--|`,
+              `| URL | ${url} |`,
+              `| Health | ${url}${HEALTH_PATH} |`,
+              `| Namespace | \`${ns}\` |`,
+              `| ArgoCD | [\`${app}\`](${argo}) |`,
+              "",
+              "Spinning up — give it a couple of minutes for image + kustomize OCI builds to publish and for ArgoCD to sync.",
+              "Closing this PR tears the preview down automatically.",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: num,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Extracts the inline `actions/github-script` bot-comment workflow that posts a sticky **🚀 Preview environment** comment on PR open/reopen. Currently duplicated inline in `homerun2-omni-pitcher/.github/workflows/comment-preview-url.yaml` and `homerun2-core-catcher/.github/workflows/comment-preview-url.yaml` (~60 lines each).

After this lands, per-component caller files become ~10 lines and the conventions (URL shape, namespace shape, ArgoCD link) live in one place.

## Inputs

| Input | Required | Default | Purpose |
|---|---|---|---|
| `hostname-prefix` | yes | — | per-PR hostname stub (e.g. `omni-pr`, `cc-pr`, `scout-pr`) |
| `hostname-domain` | yes | — | domain suffix (e.g. `homerun2-dev.sthings-vsphere.labul.sva.de`) |
| `namespace-prefix` | yes | — | per-PR namespace stub (e.g. `homerun2-pr`, `homerun2-core-catcher-pr`) |
| `argocd-app-prefix` | no | `namespace-prefix` | per-PR ArgoCD parent Application stub |
| `argocd-base-url` | no | `argocd.platform.sthings-vsphere.labul.sva.de` | ArgoCD UI hostname |
| `health-path` | no | `/health` | service health endpoint |

Full URL pattern: `https://<hostname-prefix>-<num>.<hostname-domain>`
Namespace pattern: `<namespace-prefix>-<num>`
ArgoCD app pattern: `<argocd-app-prefix>-<num>`

## Caller example

```yaml
jobs:
  comment:
    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
    with:
      hostname-prefix: scout-pr
      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
      namespace-prefix: homerun2-scout-pr
    secrets: inherit  # pragma: allowlist secret
```

## Motivation

Per stuttgart-things/homerun2-omni-pitcher#116 step 3: rolling the per-PR preview pattern out to 7 more components. Each currently means copy-pasting the same 60-line github-script — this lifts that to a reusable so the rollout PRs touch only thin caller files.

## Test plan

- [x] YAML valid, indentation consistent with sibling `call-*` workflows
- [x] Required vs. defaulted inputs documented
- [ ] After merge: backport `homerun2-omni-pitcher` and `homerun2-core-catcher` callers (separate PRs); verify the sticky comment still appears unchanged on a re-opened PR
- [ ] First new consumer: `homerun2-scout` (part of #116 step 3)