### PR TITLE
chore(deps): bump default go-version to 1.26.0

### DIFF
--- a/.github/workflows/call-go-release.yaml
+++ b/.github/workflows/call-go-release.yaml
@@ -7,7 +7,7 @@ on:
         default: ubuntu-latest
         type: string
       go-version:
-        default: "1.25.5"
+        default: "1.26.0"
         type: string
       goreleaser-version:
         default: v2.13.3

--- a/.github/workflows/call-ko-build.yaml
+++ b/.github/workflows/call-ko-build.yaml
@@ -7,7 +7,7 @@ on:
         default: ubuntu-latest
         type: string
       go-version:
-        default: "1.25.5"
+        default: "1.26.0"
         type: string
       platforms:
         default: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Bumps the default `go-version` input on two reusable workflows from `1.25.5` → `1.26.0`:

- `call-ko-build.yaml`
- `call-go-release.yaml`

## Why

The kubernetes-monorepo `v0.36.0` → `v0.36.1` bump raises the `go` directive in consumer repos' `go.mod` from `1.25.0` to `1.26.0`. With the current default of `1.25.5`, builds fail:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.5; GOTOOLCHAIN=local)
```

Affects every Renovate PR that lands the k8s monorepo bump on a downstream consumer. Currently visible on stuttgart-things/homerun2-scout#59; the same blocker will hit every other homerun2-* repo as their Renovate PRs catch up.

Bumping the central default unblocks all consumers in one shot. Per-repo overrides via the `go-version` input still work for any repo pinning a specific patch.

`call-go-release.yaml` gets the same treatment so semantic-release runs on the same toolchain as the image build (they share `go.mod`).

## Test plan

- [ ] Once merged, re-run CI on stuttgart-things/homerun2-scout#59 — `build-pr / Build, Scan & Push Image` should pass.

## Out of scope (per-repo follow-ups)

Consumer-side **Dagger modules** have their own `goVersion` default in `dagger/main.go` (e.g. scout's pins `// +default="1.25.4"`). That's not controlled centrally — each homerun2-* repo with a dagger module needs a separate one-line bump for `build-and-test` to go green on PRs that raise the root `go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)