### PR TITLE
chore(deps): bump dagger/kcl v0.103.0 → v0.114.0 in call-push-kustomize

### DIFF
--- a/.github/workflows/call-push-kustomize.yaml
+++ b/.github/workflows/call-push-kustomize.yaml
@@ -23,7 +23,7 @@ on:
         type: string
         description: "Tag to push, e.g. pr-42-abc1234 or v1.2.3"
       dagger-kcl-module:
-        default: github.com/stuttgart-things/dagger/kcl@v0.103.0
+        default: github.com/stuttgart-things/dagger/kcl@v0.114.0
         type: string
       dagger-version:
         default: "0.20.6"


### PR DESCRIPTION
## Summary

Bump `dagger-kcl-module` default in `call-push-kustomize.yaml` from `v0.103.0` to `v0.114.0` to pick up the parameter-newline fix (stuttgart-things/dagger#271, fixed by stuttgart-things/dagger#272, released as `v0.114.0`).

## What the upstream fix does

v0.114.0 stops escaping newlines as the literal 2-character sequence `\n` when reading `--parametersFile`. The old `jq -r '... gsub("\n"; "\\n") ...'` hack corrupted any multi-line value: KCL received it as a single-line string with literal backslash-n chars, emitted a single-quoted multi-line scalar in the rendered ConfigMap, and downstream consumers got garbage because the YAML spec folds single-quoted multi-line scalar newlines into spaces.

## Concrete impact

`stuttgart-things/homerun2-git-pitcher` ships a `config.watchConfigYaml: |` block in its test profile. Every release from `v0.6.0` (April 2026) onward published a broken `data: { watch-profile.yaml: 'github:\n  token: ...' }` ConfigMap that crashed the app at startup with `yaml: mapping values are not allowed in this context`. Surfaced by stuttgart-things/homerun2-git-pitcher#25 smoke.

After this bump merges and git-pitcher cuts its next release, the published kustomize OCI will ship a correct `|` block-literal scalar.

## Scope

Only `call-push-kustomize.yaml` is bumped — that's the template that exercises the buggy `--parametersFile` code path. The other two templates referencing the kcl module (`call-go-release.yaml`, `call-go-microservice-release.yaml` at v0.82.1) only invoke the `semantic` function, which doesn't go through `Run()`'s parameter handling. Bumping those can be routine maintenance, separate PR.

## Test plan

- [x] One-line diff; no behavioural change other than the module version pin
- [ ] Validate by triggering a fresh git-pitcher PR after merge and inspecting the resulting kustomize OCI:
  ```
  oras pull ghcr.io/stuttgart-things/homerun2-git-pitcher-kustomize:pr-<num>-<sha>
  grep -A 8 watch-profile configmap-homerun2-git-pitcher-watch-config.yaml
  ```
  Expect: `watch-profile.yaml: |` (block literal), not `watch-profile.yaml: '...'` (single-quoted).

Refs stuttgart-things/dagger#271
Refs stuttgart-things/dagger#272
Refs stuttgart-things/homerun2-git-pitcher#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)