### PR TITLE
chore(deps): bump dagger engine v0.20.6 → v0.20.8 in call-push-kustomize

### DIFF
--- a/.github/workflows/call-push-kustomize.yaml
+++ b/.github/workflows/call-push-kustomize.yaml
@@ -26,7 +26,7 @@ on:
         default: github.com/stuttgart-things/dagger/kcl@v0.114.0
         type: string
       dagger-version:
-        default: "0.20.6"
+        default: "0.20.8"
         type: string
     outputs:
       artifact-ref:


### PR DESCRIPTION
## Summary

Required follow-up to #90. The kcl-module v0.114.0 release (parameter-newline fix from stuttgart-things/dagger#272) bumped its engine requirement to dagger v0.20.8. With the previous v0.20.6 pin here, every push-kustomize workflow run fails on module load:

```
module requires dagger v0.20.8, but you have v0.20.6
```

Surfaced on the first PR that re-ran the workflow after #90 landed (stuttgart-things/homerun2-git-pitcher#30).

## Test plan

- [x] One-line diff
- [ ] Re-trigger stuttgart-things/homerun2-git-pitcher#30's push-kustomize after this merges; expect green and a valid `pr-30-<sha>` tag pushed to `ghcr.io/stuttgart-things/homerun2-git-pitcher-kustomize`

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)