### PR TITLE
feat(comment-preview-url): support additional-urls for co-tenant review surfaces

### DIFF
--- a/.github/workflows/call-comment-preview-url.yaml
+++ b/.github/workflows/call-comment-preview-url.yaml
@@ -38,6 +38,19 @@ on:
         default: /health
         type: string
         description: "Service health endpoint path appended to the preview URL."
+      additional-urls:
+        default: ""
+        type: string
+        description: |
+          Optional comma-separated `Label=URL` pairs to append as extra rows
+          in the comment table. Useful when the SUT's hostname isn't the
+          actual review surface — e.g. git-pitcher exposes only /health
+          and /metrics, but the events it produces are reviewed via a
+          co-tenanted core-catcher dashboard. The caller can interpolate
+          `${{ github.event.number }}` into the URL.
+
+          Example:
+            additional-urls: 'Dashboard=https://cc-git-pr-${{ github.event.number }}.homerun2-dev.example.com'
 
 permissions:
   pull-requests: write
@@ -54,18 +67,32 @@ jobs:
           ARGOCD_APP_PREFIX: ${{ inputs.argocd-app-prefix }}
           ARGOCD_BASE_URL: ${{ inputs.argocd-base-url }}
           HEALTH_PATH: ${{ inputs.health-path }}
+          ADDITIONAL_URLS: ${{ inputs.additional-urls }}
         with:
           script: |
             const num = context.issue.number;
             const {
               HOSTNAME_PREFIX, HOSTNAME_DOMAIN, NAMESPACE_PREFIX,
               ARGOCD_APP_PREFIX, ARGOCD_BASE_URL, HEALTH_PATH,
+              ADDITIONAL_URLS,
             } = process.env;
             const appPrefix = ARGOCD_APP_PREFIX || NAMESPACE_PREFIX;
             const url = `https://${HOSTNAME_PREFIX}-${num}.${HOSTNAME_DOMAIN}`;
             const ns = `${NAMESPACE_PREFIX}-${num}`;
             const app = `${appPrefix}-${num}`;
             const argo = `https://${ARGOCD_BASE_URL}/applications?search=${app}`;
+            const extraRows = (ADDITIONAL_URLS || "")
+              .split(",")
+              .map(s => s.trim())
+              .filter(s => s.length > 0)
+              .map(s => {
+                const eq = s.indexOf("=");
+                if (eq < 0) return null;
+                const label = s.slice(0, eq).trim();
+                const value = s.slice(eq + 1).trim();
+                return `| ${label} | ${value} |`;
+              })
+              .filter(Boolean);
             const marker = "<!-- preview-url-bot -->";
             const body = [
               marker,
@@ -75,6 +102,7 @@ jobs:
               `|--|--|`,
               `| URL | ${url} |`,
               `| Health | ${url}${HEALTH_PATH} |`,
+              ...extraRows,
               `| Namespace | \`${ns}\` |`,
               `| ArgoCD | [\`${app}\`](${argo}) |`,
               "",


### PR DESCRIPTION
## Summary

Adds an optional `additional-urls` input to `call-comment-preview-url.yaml`, taking a comma-separated list of `Label=URL` pairs that get appended as extra rows in the preview comment table.

## Why

`stuttgart-things/homerun2-git-pitcher`'s PR-preview shape (issue #25) puts the review surface on a **co-tenanted** workload, not on the SUT itself. git-pitcher exposes only `/health` and `/metrics` at `git-pr-<num>.…`; the events it produces are reviewed via a co-tenanted core-catcher dashboard at `cc-git-pr-<num>.…`. Without this input, the preview comment only points at the SUT hostname and reviewers have to guess at the dashboard URL.

## Caller usage

```yaml
- uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
  with:
    hostname-prefix: git-pr
    hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
    namespace-prefix: homerun2-git-pitcher-pr
    additional-urls: 'Dashboard=https://cc-git-pr-${{ github.event.number }}.homerun2-dev.sthings-vsphere.labul.sva.de'
```

Result in the comment:

```
| | |
|--|--|
| URL | https://git-pr-30.homerun2-dev.… |
| Health | https://git-pr-30.homerun2-dev.…/health |
| Dashboard | https://cc-git-pr-30.homerun2-dev.… |
| Namespace | homerun2-git-pitcher-pr-30 |
| ArgoCD | homerun2-git-pitcher-pr-30 |
```

## Compatibility

Existing callers (omni-pitcher, demo-pitcher, scout, core-catcher in this org) all pass nothing for `additional-urls` — input defaults to `""` and the extra-rows block collapses to nothing. Pure addition, no behaviour change for them.

## Test plan

- [x] Defaulted input renders identical body to today's output (manual trace through the github-script)
- [ ] Trigger by calling from a git-pitcher PR with the new field set; visually verify the Dashboard row lands between Health and Namespace

Refs stuttgart-things/homerun2-git-pitcher#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)