### PR TITLE
fix(comment-preview-url): unbreak workflow validation

### DIFF
--- a/.github/workflows/call-comment-preview-url.yaml
+++ b/.github/workflows/call-comment-preview-url.yaml
@@ -42,15 +42,18 @@ on:
         default: ""
         type: string
         description: |
-          Optional comma-separated `Label=URL` pairs to append as extra rows
+          Optional comma-separated Label=URL pairs to append as extra rows
           in the comment table. Useful when the SUT's hostname isn't the
           actual review surface — e.g. git-pitcher exposes only /health
           and /metrics, but the events it produces are reviewed via a
           co-tenanted core-catcher dashboard. The caller can interpolate
-          `${{ github.event.number }}` into the URL.
+          the PR number expression into the URL.
 
-          Example:
-            additional-urls: 'Dashboard=https://cc-git-pr-${{ github.event.number }}.homerun2-dev.example.com'
+          Example (caller-side, with PR-number interpolation rendered):
+            additional-urls: 'Dashboard=https://cc-git-pr-NUMBER.homerun2-dev.example.com'
+          Replace NUMBER with the standard github.event.number expression
+          on the caller side; embedding the raw expression here would be
+          evaluated at workflow-load time and break parsing.
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

#92 added an `additional-urls` input whose `description:` block embedded a literal `\${{ github.event.number }}` expression inside the example string. GitHub Actions evaluates `\${{ }}` even inside `description:` text, and `github.event.number` isn't resolvable at workflow-load time — every caller of this reusable workflow has been failing with the generic *"This run likely failed because of a workflow file issue"* error since #92 merged on 2026-05-18T12:40Z.

## Impact (confirmed)

- **stuttgart-things/homerun2-git-pitcher** — first failure 37s after #92 merged ([run 26034102354](https://github.com/stuttgart-things/homerun2-git-pitcher/actions/runs/26034102354))
- **stuttgart-things/homerun2-led-catcher** — every run since PR-preview workflows landed ([latest](https://github.com/stuttgart-things/homerun2-led-catcher/actions/runs/26085454217))
- All other homerun2 components (`omni-pitcher`, `core-catcher`, `scout`, `demo-pitcher`) will fail on their next `comment-preview-url` invocation until this lands.

## Fix

Rewords the example to use a `NUMBER` placeholder with a one-line note pointing readers at the caller-side expression form. Pure docs change; no behaviour change for callers.

## Test plan

- [x] YAML parses (`actionlint` / GitHub schema validation)
- [ ] After merge: retrigger any failing caller (e.g. stuttgart-things/homerun2-led-catcher#33 close+reopen) → workflow runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)