### PR TITLE
fix(create-vault-k8s-auth): bump argocd module to v2.4.1 + new kebab name

### DIFF
--- a/.github/workflows/call-create-vault-k8s-auth.yaml
+++ b/.github/workflows/call-create-vault-k8s-auth.yaml
@@ -67,7 +67,7 @@ on:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false
         type: string
-        default: v2.4.0
+        default: v2.4.1
 
 permissions:
   contents: read
@@ -94,7 +94,7 @@ jobs:
           verb: call
           module: github.com/stuttgart-things/blueprints/argocd@${{ inputs.argocd-module-version }}
           args: >-
-            create-vault-k8s-auth
+            create-vault-kubernetes-auth
             --cluster-name ${{ inputs.cluster-name }}
             --kubeconfig-source-file ${{ inputs.kubeconfig-source-file }}
             --vault-env-file ${{ inputs.vault-env-file }}


### PR DESCRIPTION
## Summary

- Default `argocd-module-version`: `v2.4.0` → `v2.4.1`
- `args:` command: `create-vault-k8s-auth` → `create-vault-kubernetes-auth`

## Why

blueprints v2.4.0 exposed `CreateVaultK8sAuth`. Dagger's kebab-case
conversion treats digit↔letter as word boundaries, so the CLI name
became `create-vault-k-8-s-auth`, NOT the documented
`create-vault-k8s-auth`. This workflow's hardcoded `args:` got:

```
Error: unknown command "create-vault-k8s-auth" for "dagger call"
```

(witnessed in [stuttgart-things#2247 run 26497548726 job](https://github.com/stuttgart-things/stuttgart-things/actions/runs/26497548726/job/78029587789))

blueprints PR [#173](https://github.com/stuttgart-things/blueprints/pull/173)
renames the Go function `CreateVaultK8sAuth` → `CreateVaultKubernetesAuth`,
which dagger renders as the clean kebab `create-vault-kubernetes-auth`
(parallel to `create-vault-issuer`).

## Test plan

> [!IMPORTANT]
> Do not merge until blueprints v2.4.1 is tagged
> (blueprints#173 merged + `task release` completed).

- [ ] blueprints#173 merged
- [ ] `git tag -l v2.4.1` on blueprints repo returns the tag
- [ ] After merge: re-trigger stuttgart-things#2247 and confirm Create-Vault-K8s-Auth job passes