### PR TITLE
feat(crossplane): add crossplane-verify reusable workflow

### DIFF
--- a/.github/workflows/call-crossplane-verify.yaml
+++ b/.github/workflows/call-crossplane-verify.yaml
@@ -1,0 +1,63 @@
+---
+name: Crossplane Configuration Verification with Dagger
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+      environment-name:
+        required: false
+        type: string
+        default: k8s
+      src:
+        description: >-
+          Path to a single Crossplane Configuration directory
+          (containing crossplane.yaml, apis/, examples/).
+        required: true
+        type: string
+      provider-kubernetes-version:
+        description: >-
+          provider-kubernetes version whose CRD schemas are used for Layer 2
+          (Object wrapper) validation. Should match the dependsOn floor in the
+          Configuration's crossplane.yaml.
+        required: false
+        type: string
+        default: v1.2.0
+      dagger-version:
+        description: "Dagger CLI version"
+        required: false
+        type: string
+        default: "0.20.8"
+      crossplane-module-version:
+        description: "Version of stuttgart-things/dagger/crossplane to invoke"
+        required: false
+        type: string
+        default: v0.115.0
+
+permissions:
+  contents: read
+
+jobs:
+  Crossplane-Verify:
+    name: Crossplane Verify (${{ inputs.src }})
+    runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment-name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify Configuration
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: ${{ inputs.dagger-version }}
+          verb: call
+          module: github.com/stuttgart-things/dagger/crossplane@${{ inputs.crossplane-module-version }}
+          args: >-
+            verify
+            --src ${{ inputs.src }}
+            --provider-kubernetes-version ${{ inputs.provider-kubernetes-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
## Summary
- New `call-crossplane-verify.yaml` reusable that invokes `github.com/stuttgart-things/dagger/crossplane@v0.115.0` → `verify` on a single Configuration directory.
- The dagger module's `verify` runs four layers per example XR: `xpkg build`, XR ↔ XRD (kubeconform), Object-wrapper schema (provider-kubernetes CRDs), and embedded `spec.forProvider.manifest` (built-in k8s schemas).
- Inputs expose the dagger module pin, dagger CLI version, and `provider-kubernetes-version` (default `v1.2.0`, matches the current `cloud-config` Configuration's dependsOn floor).

Closes the workflow side of stuttgart-things/dagger#277. Consumer wiring lands separately in `stuttgart-things/crossplane-configurations`.

## Test plan
- [ ] Open consumer PR in `stuttgart-things/crossplane-configurations` referencing `@main` once merged.
- [ ] Confirm the `Crossplane-Verify (k8s/cloud-config)` matrix job runs the dagger `verify` and reports ✓ for each `examples/xr*.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)