### PR TITLE
chore(crossplane-verify): bump default dagger module to v0.115.2

### DIFF
--- a/.github/workflows/call-crossplane-verify.yaml
+++ b/.github/workflows/call-crossplane-verify.yaml
@@ -34,7 +34,11 @@ on:
         description: "Version of stuttgart-things/dagger/crossplane to invoke"
         required: false
         type: string
-        default: v0.115.0
+        # v0.115.2: verify Layer 3 skips embedded CRDs without a built-in
+        # schema (-ignore-missing-schemas), and render is fed examples/
+        # EnvironmentConfigs via --extra-resources so XRs that set
+        # spec.environmentConfig resolve offline.
+        default: v0.115.2
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Bump the default `crossplane-module-version` of the reusable `call-crossplane-verify.yaml` workflow from `v0.115.0` to `v0.115.2`.

## Why

`v0.115.2` of `stuttgart-things/dagger/crossplane` fixes two verify failures that surfaced with the first Configuration to embed a non-core resource (`cicd/ansible-run`, which wraps a Tekton `PipelineRun`):

1. **Layer 3** (PR stuttgart-things/dagger#286, v0.115.1) — `-ignore-missing-schemas` so embedded CRDs the harness has no built-in schema for are skipped instead of hard-failing (`could not find schema for PipelineRun`). Core resources stay strictly validated.
2. **Render** (PR stuttgart-things/dagger#287, v0.115.2) — `examples/` EnvironmentConfigs are passed to `crossplane render` via `--extra-resources`, so an XR that sets `spec.environmentConfig` resolves offline instead of failing with `expected exactly one required resource, got 0`.

Bumping the org-wide default lets all consumers pick up the fix without a per-repo pin. `crossplane-configurations` currently pins `v0.115.2` explicitly (verified green); that pin can be dropped once this lands.

Verified end-to-end against `cicd/ansible-run`: all example XRs pass verify in real CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)