### PR TITLE
chore(renovate): pin GitHub Actions to SHA digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
Adds the `helpers:pinGitHubActionDigests` Renovate preset so all GitHub Actions `uses:` refs get converted to SHA-pinned digests (with `# vX.Y.Z` version comments) and kept updated automatically.

Context: this repo ships 42 reusable workflows + 2 composite actions consumed org-wide; currently zero actions are SHA-pinned.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)