### PR TITLE
chore(hugo-build): pin notify-microsoft-teams to digest

### DIFF
--- a/.github/workflows/call-hugo-build.yaml
+++ b/.github/workflows/call-hugo-build.yaml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/deploy-pages@v5.0.0 # or the latest "vX.X.X" version tag for this action
 
       - name: Microsoft Teams Notification
-        uses: skitionek/notify-microsoft-teams@master
+        uses: skitionek/notify-microsoft-teams@40873aa494cbb4fd3fea7773973df17d1358e48d # master
         if: always()
         with:
           webhook_url: ${{ secrets.MS_TEAMS_URL }}


### PR DESCRIPTION
Replaces the floating `skitionek/notify-microsoft-teams@master` ref in `call-hugo-build.yaml` with a SHA-pinned digest (`40873aa`, master) plus a `# master` comment.

This was the highest-risk third-party supply-chain ref in the templates — a `@master` branch ref to an external action, consumed org-wide. Renovate's `helpers:pinGitHubActionDigests` preset (merged in #102) will keep the digest updated from here on.

Part of the #101 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)