### PR TITLE
chore(workflows): normalize action tags to exact patch versions

### DIFF
--- a/.github/workflows/call-argocd-bootstrap.yaml
+++ b/.github/workflows/call-argocd-bootstrap.yaml
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload rendered config
         if: ${{ inputs.artifact-name != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.output-path }}

--- a/.github/workflows/call-comment-preview-url.yaml
+++ b/.github/workflows/call-comment-preview-url.yaml
@@ -62,7 +62,7 @@ jobs:
   comment:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@v9.0.0
         env:
           HOSTNAME_PREFIX: ${{ inputs.hostname-prefix }}
           HOSTNAME_DOMAIN: ${{ inputs.hostname-domain }}

--- a/.github/workflows/call-dagger-ko-build.yaml
+++ b/.github/workflows/call-dagger-ko-build.yaml
@@ -56,7 +56,7 @@ jobs:
       image-ref: ${{ steps.ko.outputs.image-ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install Dagger CLI
         run: |
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload image ref artifact
         if: ${{ inputs.image-ref-artifact != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ inputs.image-ref-artifact }}
           path: image-ref.txt

--- a/.github/workflows/call-dagger-security-scan.yaml
+++ b/.github/workflows/call-dagger-security-scan.yaml
@@ -39,7 +39,7 @@ jobs:
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Run gosec
         uses: dagger/dagger-for-github@v8.4.1
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: security-report.txt

--- a/.github/workflows/call-dagger-trivy-image-scan.yaml
+++ b/.github/workflows/call-dagger-trivy-image-scan.yaml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Download image ref artifact
         if: ${{ inputs.image-ref-artifact != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.image-ref-artifact }}
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: trivy-image-report.txt

--- a/.github/workflows/call-deploy-pages.yaml
+++ b/.github/workflows/call-deploy-pages.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.branch-name }}
 
@@ -110,7 +110,7 @@ jobs:
         run: mkdocs build -f mkdocs-pages.yml -d public
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: public
 
@@ -124,4 +124,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/call-go-microservice-release.yaml
+++ b/.github/workflows/call-go-microservice-release.yaml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/call-go-release.yaml
+++ b/.github/workflows/call-go-release.yaml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/call-helm-verify.yaml
+++ b/.github/workflows/call-helm-verify.yaml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload Polaris report
         if: inputs.run-polaris && always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: polaris-${{ inputs.chart-path }}
           path: /tmp/polaris.json

--- a/.github/workflows/call-hugo-build.yaml
+++ b/.github/workflows/call-hugo-build.yaml
@@ -39,7 +39,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Execute blog creation script
         run: |

--- a/.github/workflows/call-ko-build.yaml
+++ b/.github/workflows/call-ko-build.yaml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/call-minio-sync.yaml
+++ b/.github/workflows/call-minio-sync.yaml
@@ -45,7 +45,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}

--- a/.github/workflows/call-pre-commit.yaml
+++ b/.github/workflows/call-pre-commit.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload findings
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: pre-commit-findings
           path: ${{ inputs.output-file }}

--- a/.github/workflows/call-push-kustomize.yaml
+++ b/.github/workflows/call-push-kustomize.yaml
@@ -48,7 +48,7 @@ jobs:
       artifact-ref: ${{ steps.ref.outputs.artifact-ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Push kustomize base
         uses: dagger/dagger-for-github@v8.4.1

--- a/.github/workflows/call-repository-linting.yaml
+++ b/.github/workflows/call-repository-linting.yaml
@@ -70,7 +70,7 @@ jobs:
     environment: ${{ inputs.environment-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch-name }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload linting results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: linting-results
           path: ${{ inputs.output-file }}

--- a/.github/workflows/call-stage-image.yaml
+++ b/.github/workflows/call-stage-image.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Copy image with crane
         uses: dagger/dagger-for-github@v8.4.1

--- a/.github/workflows/call-terraform-execution.yaml
+++ b/.github/workflows/call-terraform-execution.yaml
@@ -51,7 +51,7 @@ jobs:
       dir_exists: ${{ steps.check-directory.outputs.DIR_EXISTS }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}


### PR DESCRIPTION
Normalizes the inconsistent action tag styles across all reusable workflows so each action is pinned one consistent way (exact patch tag), using the version already present elsewhere in the repo — **no version changes, no major/minor bumps**.

| Action | Before (mixed) | After |
|---|---|---|
| `actions/checkout` | `@v6` / `@v6.0.2` | `@v6.0.2` |
| `actions/upload-artifact` | `@v7` / `@v7.0.1` | `@v7.0.1` |
| `actions/download-artifact` | `@v8` / `@v8.0.1` | `@v8.0.1` |
| `actions/github-script` | `@v9` / `@v9.0.0` | `@v9.0.0` |
| `actions/upload-pages-artifact` | `@v5` / `@v5.0.0` | `@v5.0.0` |
| `actions/deploy-pages` | `@v5` / `@v5.0.0` | `@v5.0.0` |

17 files changed, 23 lines. Actions that were only ever referenced as major (`setup-go@v6`, `setup-python@v6`, `goreleaser@v7`, `setup-terraform@v4`, `ko-build/setup-ko@v0.9`) are left as-is. Renovate's digest-pinning (#102) will later add SHA digests on top, keeping these exact versions in the `# vX.Y.Z` comments.

Completes the #101 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)