### PR TITLE
feat: add build-path input to call-go-release

### DIFF
--- a/.github/workflows/call-go-release.yaml
+++ b/.github/workflows/call-go-release.yaml
@@ -20,6 +20,13 @@ on:
         default: linux/amd64,linux/arm64
         type: string
         description: Target platforms for container image build
+      build-path:
+        default: "."
+        type: string
+        description: >-
+          Import path / directory of the package main built by ko. Defaults to
+          the repo root; set to e.g. ./cmd/server when the entrypoint is not at
+          the root.
       push-kustomize:
         default: false
         type: boolean
@@ -128,7 +135,7 @@ jobs:
         run: |
           export BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           VERSION="${{ steps.version-after.outputs.version }}"
-          ko build --bare --tags="${VERSION}" . \
+          ko build --bare --tags="${VERSION}" ${{ inputs.build-path }} \
             --platform=${{ inputs.image-platforms }}
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
`call-go-release.yaml` hardcodes `ko build --bare ... .`, building the repo root. Projects whose `package main` is not at the root (e.g. `./cmd/server`) fail the staged-image step:

```
Error: failed to publish images: importpath "ko://." is not supported: importpath is not `package main`
```

This adds a **backward-compatible** `build-path` input (default `.`), mirroring the existing `build-path` in `call-ko-build.yaml`, and uses it in the ko build step. Existing consumers (root `main.go`, e.g. clusterbook) are unaffected; repos with a `cmd/` layout can now pass `build-path: ./cmd/server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)