### PR TITLE
feat: pin released image in pushed kustomize base

### DIFF
--- a/.github/workflows/call-go-release.yaml
+++ b/.github/workflows/call-go-release.yaml
@@ -40,6 +40,15 @@ on:
       kustomize-oci-repo:
         default: ""
         type: string
+      kustomize-image-key:
+        default: ""
+        type: string
+        description: >-
+          KCL option key for the container image (e.g. config.image). When set
+          and push-kustomize is enabled, the pushed kustomize base pins this key
+          to the released image ghcr.io/<repo>:<version>, overriding whatever the
+          profile file specifies (e.g. :latest). Leave empty to keep the
+          profile's value.
       dry-run-only:
         default: false
         type: boolean
@@ -151,6 +160,7 @@ jobs:
             push-kustomize-base
             --source ./${{ inputs.kcl-source-dir }}
             --parameters-file ./${{ inputs.kcl-profile-file }}
+            ${{ inputs.kustomize-image-key != '' && format('--parameters {0}=ghcr.io/{1}:{2}', inputs.kustomize-image-key, github.repository, steps.version-after.outputs.version) || '' }}
             --address ${{ inputs.kustomize-oci-repo }}
             --tag ${{ steps.version-after.outputs.version }}
             --user env:GITHUB_USER


### PR DESCRIPTION
The pushed kustomize base takes its container image from the KCL profile file's static value (e.g. `config.image: …:latest`). For a versioned kustomize OCI artifact that's wrong — the `v0.1.0` artifact should reference `:v0.1.0`, and `:latest` often isn't even published (so the artifact fails to pull).

This adds an **opt-in** `kustomize-image-key` input. When set (e.g. `config.image`) and `push-kustomize` is enabled, the dagger `push-kustomize-base` call gets `--parameters <key>=ghcr.io/<repo>:<version>`, which KCL applies as `-D` (overriding the profile's `-Y` value). The pushed base then pins the matching released image.

Backward compatible: empty by default, so existing consumers (e.g. clusterbook) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)