### PR TITLE
fix(crossplane-verify): bump dagger crossplane module default to v0.118.0

### DIFF
--- a/.github/workflows/call-crossplane-verify.yaml
+++ b/.github/workflows/call-crossplane-verify.yaml
@@ -34,11 +34,16 @@ on:
         description: "Version of stuttgart-things/dagger/crossplane to invoke"
         required: false
         type: string
-        # v0.115.2: verify Layer 3 skips embedded CRDs without a built-in
-        # schema (-ignore-missing-schemas), and render is fed examples/
-        # EnvironmentConfigs via --extra-resources so XRs that set
-        # spec.environmentConfig resolve offline.
-        default: v0.115.2
+        # v0.118.0: pins the crank CLI to v2.2.2 and tolerates the crossplane
+        # release bucket's currently-mismatched crank.sha256. Earlier versions
+        # tracked the `stable` channel's floating `current` marker, so when it
+        # advanced to crank v2.3.0 (which runs `crossplane internal render` in
+        # Docker, incompatible with the function images) render broke for every
+        # function-based Configuration with no code change. See
+        # stuttgart-things/dagger#295. Carries forward the v0.115.2 behaviour
+        # (Layer 3 -ignore-missing-schemas; EnvironmentConfigs via
+        # --extra-resources for offline render).
+        default: v0.118.0
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`call-crossplane-verify.yaml` defaulted `crossplane-module-version` to **v0.115.2**, whose container installs the crank CLI from the `stable` channel's floating `current` marker. When `current` advanced to **crank v2.3.0** — which runs `crossplane render` by re-exec'ing `crossplane internal render` inside the function Docker container (incompatible with the crossplane-contrib function images) — render started failing for **every** function-based Configuration, with no code change:

```
crossplane: error: cannot render composite resource: cannot run crossplane internal render
in Docker: container exited with status 1: crossplane: error: unexpected argument internal
```

## Fix

Bump the default to **v0.118.0**, which:
- pins crank to **v2.2.2** (last release whose render runs functions compatibly), and
- tolerates the crossplane release bucket's currently-mismatched `crank.sha256` (warn + authoritative run-check instead of hard-fail).

Behaviour from v0.115.2 (Layer 3 `-ignore-missing-schemas`; EnvironmentConfigs via `--extra-resources` for offline render) is carried forward.

Consumers referencing this workflow `@main` pick the fix up automatically; any consumer overriding the input keeps its own value.

See stuttgart-things/dagger#295 (root cause + fix chain: dagger#296 pin, dagger#298 checksum tolerance).