### PR TITLE
ci(crossplane-verify): bump default crossplane-module-version to v0.118.1 (fixes #300 render)

### DIFF
--- a/.github/workflows/call-crossplane-verify.yaml
+++ b/.github/workflows/call-crossplane-verify.yaml
@@ -43,7 +43,10 @@ on:
         # stuttgart-things/dagger#295. Carries forward the v0.115.2 behaviour
         # (Layer 3 -ignore-missing-schemas; EnvironmentConfigs via
         # --extra-resources for offline render).
-        default: v0.118.0
+        # v0.118.1: runs render Functions as Dagger services instead of nested
+        # Docker containers, fixing the function-kcl render-sandbox failure
+        # (DeadlineExceeded / connection refused) — stuttgart-things/dagger#300.
+        default: v0.118.1
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Bumps the default `crossplane-module-version` in `call-crossplane-verify.yaml` from **v0.118.0 → v0.118.1**.

## Why

v0.118.0's `crossplane render` started each Composition Function as a **nested Docker container**, which can't start inside the Dagger sandbox on GitHub runners (`cgroup.subtree_control: no such file or directory`) — so crossplane's dial to the function gRPC port is refused and the render times out with `DeadlineExceeded`. This silently broke the verify render layer for **every `function-kcl`-based Configuration** in every repo that calls this reusable workflow.

Reported as **[stuttgart-things/dagger#300](https://github.com/stuttgart-things/dagger/issues/300)**, fixed in **dagger#301** (render Functions now run as **Dagger services**), released as **v0.118.1**.

## Effect

All consumer repos pick up the fix automatically — no per-repo override needed. (`crossplane-configurations` currently carries a temporary explicit override; it can drop it once this lands.)