### PR TITLE
feat(kcl): add call-kcl-validate reusable workflow

### DIFF
--- a/.github/workflows/call-kcl-validate.yaml
+++ b/.github/workflows/call-kcl-validate.yaml
@@ -1,0 +1,144 @@
+---
+name: KCL Validation with Dagger
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+      environment-name:
+        required: false
+        type: string
+        default: validation
+      module-dir:
+        description: >-
+          Path to a single KCL module directory (containing kcl.mod and the
+          entrypoint) relative to the checkout root, e.g. "kcl/ansible".
+        required: true
+        type: string
+      entrypoint:
+        description: "KCL entrypoint file inside module-dir (passed to `run --entrypoint`)."
+        required: false
+        type: string
+        default: main.k
+      fmt-check:
+        description: >-
+          Run a formatting check. `kcl fmt` has no native --check flag, so this
+          runs `kcl fmt <module-dir>` in place and fails if it produces a diff
+          (git diff --exit-code). Run `kcl fmt <module-dir>` locally and commit
+          to fix.
+        required: false
+        type: boolean
+        default: true
+      flat-parameters:
+        description: >-
+          Optional flat-mode (`-D`) render parameters forwarded verbatim to the
+          dagger kcl `run --parameters`. Comma-separated key=value pairs, e.g.
+          "namespace=tekton-ci,storageSize=20Mi". When empty the flat render is
+          skipped (the validate step already renders the entrypoint with
+          defaults). Values must not contain spaces.
+        required: false
+        type: string
+        default: ""
+      composition-parameters:
+        description: >-
+          Optional composition-mode render parameters forwarded verbatim to
+          `run --parameters`, e.g. "params={oxr:{spec:{namespace:tekton-ci}}}".
+          When empty the composition render is skipped. Values must not contain
+          spaces.
+        required: false
+        type: string
+        default: ""
+      dagger-version:
+        description: "Dagger CLI version"
+        required: false
+        type: string
+        default: "0.20.8"
+      kcl-module-version:
+        description: "Version of stuttgart-things/dagger/kcl to invoke"
+        required: false
+        type: string
+        default: v0.82.1
+      kcl-image:
+        description: "KCL CLI image used for the formatting check"
+        required: false
+        type: string
+        default: kcllang/kcl:v0.12.3
+      continue-on-error:
+        description: "When true, validation failures don't fail the job (advisory runs)."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  KCL-Validate:
+    name: KCL Validate (${{ inputs.module-dir }})
+    runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment-name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Format check (kcl fmt + git diff)
+        if: inputs.fmt-check
+        continue-on-error: ${{ inputs.continue-on-error }}
+        run: |
+          set -eu
+          echo "==> kcl fmt ${{ inputs.module-dir }}"
+          docker run --rm -v "$PWD":/work -w /work "${{ inputs.kcl-image }}" \
+            kcl fmt "${{ inputs.module-dir }}"
+          if ! git diff --exit-code -- "${{ inputs.module-dir }}"; then
+            echo "::error::kcl fmt produced changes in ${{ inputs.module-dir }} — run 'kcl fmt ${{ inputs.module-dir }}' locally and commit"
+            exit 1
+          fi
+          echo "formatting OK"
+
+      - name: Validate (compile entrypoint)
+        continue-on-error: ${{ inputs.continue-on-error }}
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
+        with:
+          version: ${{ inputs.dagger-version }}
+          verb: call
+          module: github.com/stuttgart-things/dagger/kcl@${{ inputs.kcl-module-version }}
+          args: >-
+            validate-kcl
+            --source ${{ inputs.module-dir }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Render (flat mode)
+        if: inputs.flat-parameters != ''
+        continue-on-error: ${{ inputs.continue-on-error }}
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
+        with:
+          version: ${{ inputs.dagger-version }}
+          verb: call
+          module: github.com/stuttgart-things/dagger/kcl@${{ inputs.kcl-module-version }}
+          args: >-
+            run
+            --source ${{ inputs.module-dir }}
+            --entrypoint ${{ inputs.entrypoint }}
+            --parameters ${{ inputs.flat-parameters }}
+            contents
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Render (composition mode)
+        if: inputs.composition-parameters != ''
+        continue-on-error: ${{ inputs.continue-on-error }}
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
+        with:
+          version: ${{ inputs.dagger-version }}
+          verb: call
+          module: github.com/stuttgart-things/dagger/kcl@${{ inputs.kcl-module-version }}
+          args: >-
+            run
+            --source ${{ inputs.module-dir }}
+            --entrypoint ${{ inputs.entrypoint }}
+            --parameters ${{ inputs.composition-parameters }}
+            contents
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -135,6 +135,31 @@ jobs:
 
 </details>
 
+<details><summary>KCL VALIDATE</summary>
+
+```yaml
+jobs:
+  kcl-validate:
+    name: KCL Validate
+    strategy:
+      matrix:
+        module-dir: [kcl/ansible, kcl/ansible-run, kcl/buildah]
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-kcl-validate.yaml@main
+    with:
+      module-dir: ${{ matrix.module-dir }}
+    secrets: inherit
+```
+
+Validates one KCL module directory per call via the `stuttgart-things/dagger/kcl`
+module: a formatting check (`kcl fmt` + `git diff --exit-code`, since `kcl fmt`
+has no native `--check` flag) and a compile/render check (`validate-kcl`).
+Optionally renders the entrypoint with caller-supplied `flat-parameters`
+(`-D` key=value) and/or `composition-parameters`
+(`params={oxr:{spec:{...}}}`) — parameter values must not contain spaces. Use a
+matrix in the caller to cover multiple modules.
+
+</details>
+
 ## ACTIONS
 
 <details><summary>SEND MESSAGE TO HOMERUN</summary>


### PR DESCRIPTION
## What

Add a Dagger-based reusable workflow `call-kcl-validate.yaml` that validates a single KCL module directory via the `stuttgart-things/dagger/kcl` module:

- **Format check** — `kcl fmt` + `git diff --exit-code`. `kcl fmt` has **no native `--check` flag**, so we format in place and fail on a diff (the standard idiom).
- **Compile/render check** — `validate-kcl --source <module-dir>` (renders the entrypoint with defaults; catches broken schemas/renders).
- **Optional renders** — flat-mode (`-D` key=value) and composition-mode (`params={oxr:{spec:{…}}}`) via caller-supplied `--parameters`. Parameter values must not contain spaces (the Dagger `run --parameters` splits on commas).

README documents the template and a matrix caller example.

## Why

Consumed by `stuttgart-things/stage-time` to add a KCL render check on PRs (see stuttgart-things/stage-time#34). No existing template covered `kcl fmt`/`kcl run` validation.

## Notes

- Engine is Dagger, matching the repo convention (`call-pre-commit.yaml`, `call-crossplane-verify.yaml`).
- Defaults: `dagger/kcl@v0.82.1`, `kcllang/kcl:v0.12.3` (fmt), `runs-on: ubuntu-latest`.
- This must merge before the stage-time caller that references `call-kcl-validate.yaml@main`.

https://claude.ai/code/session_01KLjXXpPmBZyv8S63Ky7odj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjXXpPmBZyv8S63Ky7odj)_