### PR TITLE
fix(ansible): bump default dagger module to v0.120.0

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -17,11 +17,11 @@ on:
       dagger-version:
         required: false
         type: string
-        default: 0.18.10
+        default: v0.21.7
       dagger-module-version:
         required: false
         type: string
-        default: v0.13.0
+        default: v0.120.0
       environment-name:
         required: false
         type: string


### PR DESCRIPTION
## Why

`call-ansible-collection.yaml` defaulted to `dagger/ansible@v0.13.0` and `dagger 0.18.10`. The module is at **v0.120.0** — the default was over 100 versions behind.

This stayed invisible because the only known caller, `stuttgart-things/ansible`, passes its own explicit pins. Any caller relying on the defaults, though, got a module old enough to predate the metadata fix.

`v0.120.0` is the first version that derives `galaxy.yml` from `collection.yaml` instead of hardcoding the template (stuttgart-things/dagger#320). Collections built with the old default shipped placeholder metadata and declared **`GPL-2.0-or-later`** regardless of their actual license.

## Changes

| input | before | after |
|---|---|---|
| `dagger-module-version` | `v0.13.0` | `v0.120.0` |
| `dagger-version` | `0.18.10` | `v0.21.7` |

`v0.21.7` matches `engineVersion` in the module's `dagger.json` and the value `stuttgart-things/ansible` already passes, so the `v` prefix is a format the action is known to accept in practice.

## Verification

Defaults only — no behaviour change for callers passing explicit values, which covers every known caller today.

`v0.120.0` was exercised end to end through this workflow at stuttgart-things/ansible#1044: all four collections built and released, and the published artifacts' `MANIFEST.json` now read `license: ["Apache-2.0"]` with correct authors and tags, where every prior release said `GPL-2.0-or-later`.

YAML re-validated.

## Related

- stuttgart-things/dagger#320 — the module fix
- stuttgart-things/ansible#1045 — caller-side bump
- stuttgart-things/ansible#1044 — explicit collection metadata
- stuttgart-things/ansible#1043 — remaining build/release findings, including SHA-pinning the `@main` reference to this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY
