### PR TITLE
feat(ansible): gate collection release behind publish-release input

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -26,6 +26,13 @@ on:
         required: false
         type: string
         default: k8s
+      publish-release:
+        description: >-
+          Publish the built collection as a github release. Set false on
+          pull_request builds so only merges to the default branch release.
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   collection-build:
@@ -85,6 +92,7 @@ jobs:
 
   Release-Collection:
     needs: collection-build
+    if: ${{ inputs.publish-release }}
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-artifact.yaml@bb83ff4e6dea2373835dcd6ec27aa3fcd3b592e7 # main
     with:
       runs-on: ${{ inputs.runs-on }}


### PR DESCRIPTION
## Why

`Release-Collection` runs unconditionally after every build, so a caller has no way to build a collection without publishing it.

`stuttgart-things/ansible` triggers this workflow on `pull_request`. Every PR that touches `collections/**` — most of them Renovate bumps — therefore cuts a **public GitHub release from unreviewed branch code**, including for branches that are later closed and never merged. That repo is at 800+ releases, roughly 2.6 a day.

## Change

New `publish-release` input, applied as a job-level condition:

```yaml
  Release-Collection:
    needs: collection-build
    if: ${{ inputs.publish-release }}
```

## No-op for existing callers

Defaults to `true`, so current behaviour is unchanged for anyone who does not set it.

`stuttgart-things/ansible` is the only caller today (verified by org-wide code search). It will pass `false` on its `pull_request` path and `true` on merges to `main`, in a follow-up PR there — this one must land first, since referencing an unknown input fails the workflow.

The `collection-build` job already uploads the artifact via `upload-artifact`, so PR builds keep producing something reviewers can download.

## Related

- stuttgart-things/ansible#1043 — finding #2, which this unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY