### PR TITLE
fix(ansible): tag releases with the version, not the filename

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -38,6 +38,7 @@ jobs:
   collection-build:
     outputs:
       collection-name: ${{ steps.meta.outputs.COLLECTION_PACKAGE_NAME }}
+      collection-tag: ${{ steps.meta.outputs.COLLECTION_TAG }}
     name: Collection Build
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.environment-name }}
@@ -62,12 +63,18 @@ jobs:
           COLLECTION_PACKAGE_PATH=$(ls --time=birth /tmp/${{ inputs.collection-directory }}/*.tar.gz | head -n 1)
           COLLECTION_PACKAGE_NAME=$(basename "${COLLECTION_PACKAGE_PATH}")
 
+          # THE TAG NAMES A VERSION, NOT A FILE - THE EXTENSION BELONGS TO THE
+          # RELEASE ASSET ONLY
+          COLLECTION_TAG=$(basename "${COLLECTION_PACKAGE_PATH}" .tar.gz)
+
           echo ${COLLECTION_PACKAGE_NAME}
           echo ${COLLECTION_PACKAGE_PATH}
+          echo ${COLLECTION_TAG}
 
           echo "COLLECTION_PACKAGE_NAME=$(echo ${COLLECTION_PACKAGE_NAME})" >> $GITHUB_ENV
           echo "COLLECTION_PACKAGE_NAME=$(echo ${COLLECTION_PACKAGE_NAME})" >> $GITHUB_OUTPUT
           echo "COLLECTION_PACKAGE_PATH=$(echo ${COLLECTION_PACKAGE_PATH})" >> $GITHUB_ENV
+          echo "COLLECTION_TAG=$(echo ${COLLECTION_TAG})" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Upload collection
@@ -99,5 +106,6 @@ jobs:
       environment-name: k8s
       dagger-module-version: ${{ inputs.dagger-module-version }}
       artifact-name: ${{ needs.collection-build.outputs.collection-name }}
+      tag: ${{ needs.collection-build.outputs.collection-tag }}
       dagger-version: ${{ inputs.dagger-version }}
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/call-release-artifact.yaml
+++ b/.github/workflows/call-release-artifact.yaml
@@ -10,6 +10,13 @@ on:
       artifact-name:
         required: true
         type: string
+      tag:
+        description: >-
+          Release tag. Defaults to artifact-name, which embeds the file
+          extension - pass this to tag a version rather than a filename.
+        required: false
+        type: string
+        default: ''
       environment-name:
         required: false
         type: string
@@ -48,5 +55,5 @@ jobs:
         with:
           version: ${{ inputs.dagger-version }}
           verb: call
-          args: github-release --token=env:GH_TOKEN --group ${GITHUB_REPOSITORY%%/*} --repo ${GITHUB_REPOSITORY#*/} --notes "${{ inputs.artifact-name }}" --tag ${{ inputs.artifact-name }} --title "release for ${{ inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}" --progress plain
+          args: github-release --token=env:GH_TOKEN --group ${GITHUB_REPOSITORY%%/*} --repo ${GITHUB_REPOSITORY#*/} --notes "${{ inputs.artifact-name }}" --tag ${{ inputs.tag || inputs.artifact-name }} --title "${{ inputs.tag || inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}" --progress plain
           module: github.com/stuttgart-things/dagger/ansible@${{ inputs.dagger-module-version }}


### PR DESCRIPTION
Addresses finding #3 of stuttgart-things/ansible#1043.

## Problem

`call-release-artifact.yaml` passed `artifact-name` straight to `--tag`, so release tags carried the file extension:

```
sthings-baseos-26.2.675.tar.gz
```

which produces download URLs with the name twice over:

```
.../releases/download/sthings-baseos-26.2.675.tar.gz/sthings-baseos-26.2.675.tar.gz
```

A tag names a version. The extension belongs to the asset.

## After

```
tag:  sthings-baseos-26.2.675
url:  .../releases/download/sthings-baseos-26.2.675/sthings-baseos-26.2.675.tar.gz
```

## Changes

- `call-ansible-collection.yaml` derives `COLLECTION_TAG` alongside the package name and passes it through as a new `tag` input
- `call-release-artifact.yaml` gains an optional `tag`, falling back to `artifact-name` via `${{ inputs.tag || inputs.artifact-name }}`
- The release title follows the tag instead of keeping the extension. `--files` still uses `artifact-name`, since that one really is a filename

## Compatibility

`tag` is optional and defaults to today's behaviour, so nothing changes for a caller that does not set it. `call-ansible-collection.yaml` is its only caller today, verified by org-wide code search.

**Existing pinned URLs are unaffected** — they reference tags that already exist and are not rewritten. `stuttgart-things/ansible` currently pins four collections by full URL in `requirements.yaml`; those keep resolving. Only releases cut after this lands use the new shape, so the next pin bump there will use the new URL form.

This also settles a split in that repo: **777 tags carry `.tar.gz` and 33 do not**, because the local `task build-collection` path already stripped it (`basename … .tar.gz`) while CI did not. New tags from either path now agree.

## Not included

Renaming the 800 existing tags. They are immutable references that published URLs depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY