### PR TITLE
fix(ansible): build collections with a monotonic version

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -21,7 +21,7 @@ on:
       dagger-module-version:
         required: false
         type: string
-        default: v0.120.0
+        default: v0.121.0
       environment-name:
         required: false
         type: string
@@ -49,12 +49,33 @@ jobs:
           fetch-depth: '0'
           ref: ${{ inputs.branch-name }}
 
+      - name: Determine Collection Version
+        id: version
+        run: |
+          set -eu
+
+          # THE COMMIT COUNT IS THE ORDERING SIGNAL. A SHALLOW CLONE RETURNS A
+          # SMALL COUNT AND WOULD SILENTLY PUBLISH A LOWER VERSION THAN THE
+          # LAST RELEASE, SO REFUSE TO GUESS
+          if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+            echo "repository is shallow - checkout needs fetch-depth: 0"
+            exit 1
+          fi
+
+          # YY.MMDD.<COMMIT COUNT>: MONOTONIC ACROSS DAY, MONTH AND YEAR
+          # BOUNDARIES, AND THE PATCH TIES A RELEASE TO AN EXACT COMMIT
+          VERSION="$(date -u +%y).$(date -u +%-m%d).$(git rev-list --count HEAD)"
+
+          echo "COLLECTION VERSION: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Build Collection
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         with:
           version: ${{ inputs.dagger-version }}
           verb: call
-          args: run-collection-build-pipeline --src ${{ inputs.collection-directory }} --progress plain export --path=/tmp/${{ inputs.collection-directory }}
+          args: run-collection-build-pipeline --src ${{ inputs.collection-directory }} --version ${{ steps.version.outputs.version }} --progress plain export --path=/tmp/${{ inputs.collection-directory }}
           module: github.com/stuttgart-things/dagger/ansible@${{ inputs.dagger-module-version }}
 
       - name: Check collection artifact

--- a/.github/workflows/call-release-artifact.yaml
+++ b/.github/workflows/call-release-artifact.yaml
@@ -50,6 +50,36 @@ jobs:
           du -sh /tmp/${{ inputs.artifact-name }}
         shell: bash
 
+      - name: Refuse To Republish An Existing Tag
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag || inputs.artifact-name }}
+        run: |
+          set -eu
+
+          # A VERSION IS DERIVED FROM THE COMMIT, SO AN EXISTING TAG MEANS THIS
+          # EXACT SOURCE WAS ALREADY RELEASED. FAIL HERE WITH SOMETHING READABLE
+          # RATHER THAN LETTING THE RELEASE STEP COLLIDE
+          HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
+
+          case "${HTTP_CODE}" in
+            404)
+              echo "tag ${RELEASE_TAG} is free"
+              ;;
+            200)
+              echo "tag ${RELEASE_TAG} already exists"
+              echo "this commit was already released - commit a change to release again"
+              exit 1
+              ;;
+            *)
+              echo "could not check tag ${RELEASE_TAG}: HTTP ${HTTP_CODE}"
+              exit 1
+              ;;
+          esac
+        shell: bash
+
       - name: Release Collection
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         with:


### PR DESCRIPTION
Addresses finding #1 of stuttgart-things/ansible#1043 — the last structural problem in that pipeline.

## Problem

The module derived the version from the clock as `YY.<weekday>.<minute-of-day>`, so it **drops every time the weekday resets**. Observed consequences in `stuttgart-things/ansible`:

- Two pairs of distinct artifacts published under one version — `sthings-container-25.5.499`, `sthings-baseos-25.3.605`
- Its `requirements.yaml` pins had to move numerically *downward* (`26.3.1037` → `26.2.675`) to move *forward* in time

The module cannot fix this alone: `InitCollection` receives `collections/<name>`, a plain directory with **no git history**, so time is the only ordering signal available to it. The version has to be computed here and passed in — added as an optional `--version` in stuttgart-things/dagger#322, released as **v0.121.0**.

## Scheme: `YY.MMDD.<commit count>`

Today: `26.728.1151`.

| property | verified |
|---|---|
| Valid semver | three numeric parts |
| Above every published version | max is `26.6.1313` |
| Monotonic day → day | `26.728.1151` → `26.729.1152` |
| Monotonic month → month | `26.728.1151` → `26.801.1160` |
| Monotonic year → year | `26.1231.2000` → `27.101.2001` |

The minor carries ordering on its own, so the patch cannot cause a regression — and being a commit count, it ties a release to an exact commit.

## Shallow clones fail the build

The commit count is only correct on a full clone. A shallow one returns a small number and would **silently publish a version below the last release**. The step checks `git rev-parse --is-shallow-repository` and fails rather than guessing.

This is deliberately the same lesson as stuttgart-things/ansible#1048: the previous bug in this pipeline failed toward green, and a wrong version would too.

## Refusing to republish a commit

Because the version is derived from the commit, an existing tag means this exact source was already released. `call-release-artifact.yaml` now checks first:

```
tag sthings-baseos-26.728.1151 already exists
this commit was already released - commit a change to release again
```

It lives in the release path, so rebuilding a PR does not trip it. A non-200/404 response also fails, rather than being read as "free".

## Verification

- `v0.121.0` with `--version 26.728.1151` against `collections/baseos` → that version in `MANIFEST.json`, artifact `sthings-baseos-26.728.1151.tar.gz`
- Tag check against real tags: `sthings-baseos-26.2.675.tar.gz` → 200 (fails), `sthings-baseos-26.728.1151` → 404 (proceeds)
- Both workflows schema-validated

## Rollout

`stuttgart-things/ansible` has a companion PR passing the same version from `Taskfile.yaml`, so local and CI builds produce identical versions. This PR should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY