### PR TITLE
feat(ansible): publish checksums and build provenance for collections

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -42,6 +42,10 @@ jobs:
     name: Collection Build
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.environment-name }}
+    # THE BUILD READS SOURCE AND UPLOADS AN ARTIFACT. IT RELEASES NOTHING, SO
+    # IT NEEDS NO WRITE SCOPE ON THE CALLING REPOSITORY
+    permissions:
+      contents: read
     steps:
       - name: Checkout Project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -121,6 +125,13 @@ jobs:
   Release-Collection:
     needs: collection-build
     if: ${{ inputs.publish-release }}
+    # PASSED DOWN TO call-release-artifact.yaml, WHICH SIGNS A BUILD PROVENANCE
+    # ATTESTATION. A REUSABLE WORKFLOW CANNOT GRANT ITSELF MORE THAN ITS CALLER
+    # DID, SO THE CALLING REPOSITORY MUST GRANT THESE TOO
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-artifact.yaml@bb83ff4e6dea2373835dcd6ec27aa3fcd3b592e7 # main
     with:
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/call-release-artifact.yaml
+++ b/.github/workflows/call-release-artifact.yaml
@@ -35,6 +35,13 @@ jobs:
     name: Release artifact on github
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.environment-name }}
+    # THE CALLER MUST GRANT THESE OR attest-build-provenance FAILS. id-token
+    # SIGNS THE ATTESTATION VIA OIDC, attestations WRITES IT TO THE CALLING
+    # REPOSITORY'S ATTESTATION STORE
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
@@ -49,6 +56,29 @@ jobs:
         run: |
           du -sh /tmp/${{ inputs.artifact-name }}
         shell: bash
+
+      # CONSUMERS ansible-galaxy install FROM A PLAIN HTTPS URL WITH NOTHING TO
+      # CHECK THE DOWNLOAD AGAINST. PUBLISH THE DIGEST AS A RELEASE ASSET SO
+      # THERE IS SOMETHING TO VERIFY AGAINST
+      - name: Generate Checksum
+        id: checksum
+        run: |
+          set -eu
+          cd /tmp
+          sha256sum "${{ inputs.artifact-name }}" > "${{ inputs.artifact-name }}.sha256"
+          cat "${{ inputs.artifact-name }}.sha256"
+
+          DIGEST=$(cut -d' ' -f1 < "${{ inputs.artifact-name }}.sha256")
+          echo "sha256=${DIGEST}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      # BINDS THE ARTIFACT TO THE WORKFLOW, REPOSITORY AND COMMIT THAT PRODUCED
+      # IT. VERIFY WITH:
+      #   gh attestation verify <file> --repo <owner>/<repo>
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: /tmp/${{ inputs.artifact-name }}
 
       - name: Refuse To Republish An Existing Tag
         env:
@@ -85,5 +115,5 @@ jobs:
         with:
           version: ${{ inputs.dagger-version }}
           verb: call
-          args: github-release --token=env:GH_TOKEN --group ${GITHUB_REPOSITORY%%/*} --repo ${GITHUB_REPOSITORY#*/} --notes "${{ inputs.artifact-name }}" --tag ${{ inputs.tag || inputs.artifact-name }} --title "${{ inputs.tag || inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}" --progress plain
+          args: github-release --token=env:GH_TOKEN --group ${GITHUB_REPOSITORY%%/*} --repo ${GITHUB_REPOSITORY#*/} --notes "${{ inputs.artifact-name }} | sha256 ${{ steps.checksum.outputs.sha256 }} | commit ${{ github.sha }}" --tag ${{ inputs.tag || inputs.artifact-name }} --title "${{ inputs.tag || inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}.sha256" --progress plain
           module: github.com/stuttgart-things/dagger/ansible@${{ inputs.dagger-module-version }}


### PR DESCRIPTION
Addresses finding #9 of stuttgart-things/ansible#1043.

## The gap

Consumers install these collections with `ansible-galaxy collection install` from a plain HTTPS release URL. The release carried **no checksum, no signature, no SBOM and no provenance** — nothing to check the download against. For collections that run `become: true` and `rm -rf` across a fleet, that was the weakest link in the chain.

## Changes to `call-release-artifact.yaml`

**Checksum.** A `<artifact>.sha256` is generated and published as a second release asset. Verified that the Dagger module's `--files []File` accepts repeated flags, so both assets go up in the same `gh release create`:

```
dagger call github-release --files /tmp/a.txt --files /tmp/b.txt ...
  -> files: [xxh3:e43191c888f4ea68, xxh3:32b89fbeeb88736e]
```

(It failed only on a deliberately-missing token, after parsing both files.)

**Build provenance.** `actions/attest-build-provenance` (SHA-pinned to v4.1.1) signs an attestation binding the artifact to the workflow, repository and commit that built it:

```
gh attestation verify sthings-baseos-<version>.tar.gz --repo stuttgart-things/ansible
```

**Release notes** now carry the digest and source commit instead of repeating the filename.

## Permissions

Both jobs declare least-privilege permissions, which they did not before:

- `collection-build` — `contents: read`. It reads source and uploads an artifact; it releases nothing.
- `Release-Collection` / `release-artifact` — `contents: read`, `id-token: write` (OIDC signing), `attestations: write` (storing the result).

A reusable workflow cannot grant itself more than its caller did, so **the calling repository must grant the same** — that is the companion PR in `stuttgart-things/ansible`.

## Two things this does not do

1. **Release notes are still not a changelog.** What changed between two pins remains unanswered. Passing `--generate-notes` would need a change to the Dagger module's `GithubRelease`, which hardcodes `--notes`. Left open deliberately rather than half-done.
2. **The internal pin still points at the old SHA.** `call-ansible-collection.yaml` references `call-release-artifact.yaml@bb83ff4e`, which predates this change. A follow-up bumps it to this PR's merge commit — it cannot be written before the commit exists.

## Verification

`check-jsonschema --builtin-schema vendor.github-workflows` passes on both files. The attestation path itself cannot be exercised until a real collection release runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY