### PR TITLE
fix(ansible): pin call-release-artifact to the provenance commit

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -132,7 +132,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-artifact.yaml@bb83ff4e6dea2373835dcd6ec27aa3fcd3b592e7 # main
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-artifact.yaml@1814f1e31dddaab2273396879d0ff2d4bcb05efe # main
     with:
       runs-on: ${{ inputs.runs-on }}
       environment-name: k8s


### PR DESCRIPTION
Follow-up to #125, which called this out as the one thing it could not do itself.

`call-ansible-collection.yaml` pinned `call-release-artifact.yaml@bb83ff4e`, a commit that predates #125. Left as-is, the collection release path keeps invoking the **old** release workflow — so no checksum and no attestation would ever be produced, despite #125 being merged and looking done.

Bumped to `1814f1e`, the merge commit of #125.

This is the failure mode the audit keeps running into: a change that appears shipped but is bypassed by a stale reference. Worth noting that a SHA pin needs a deliberate bump to take effect at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY