### PR TITLE
fix(ansible): document the attestation verify command correctly

### DIFF
--- a/.github/workflows/call-release-artifact.yaml
+++ b/.github/workflows/call-release-artifact.yaml
@@ -74,7 +74,16 @@ jobs:
 
       # BINDS THE ARTIFACT TO THE WORKFLOW, REPOSITORY AND COMMIT THAT PRODUCED
       # IT. VERIFY WITH:
-      #   gh attestation verify <file> --repo <owner>/<repo>
+      #   gh attestation verify <file> \
+      #     --repo <owner>/<repo> \
+      #     --signer-repo stuttgart-things/github-workflow-templates
+      #
+      # --signer-repo IS NOT OPTIONAL. THE SIGNING IDENTITY IN THE CERTIFICATE
+      # IS THIS REUSABLE WORKFLOW, WHICH LIVES IN A DIFFERENT REPOSITORY FROM
+      # THE ARTIFACT. WITHOUT IT gh LOOKS FOR A SIGNER IN THE ARTIFACT'S OWN
+      # REPO, FINDS NONE, AND FAILS WITH A BARE
+      #   Error: verifying with issuer "sigstore.dev"
+      # WHICH READS LIKE A BAD ARTIFACT RATHER THAN A BAD COMMAND
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
@@ -115,5 +124,5 @@ jobs:
         with:
           version: ${{ inputs.dagger-version }}
           verb: call
-          args: github-release --token=env:GH_TOKEN --group ${GITHUB_REPOSITORY%%/*} --repo ${GITHUB_REPOSITORY#*/} --notes "${{ inputs.artifact-name }} | sha256 ${{ steps.checksum.outputs.sha256 }} | commit ${{ github.sha }}" --tag ${{ inputs.tag || inputs.artifact-name }} --title "${{ inputs.tag || inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}.sha256" --progress plain
+          args: github-release --token=env:GH_TOKEN --group ${GITHUB_REPOSITORY%%/*} --repo ${GITHUB_REPOSITORY#*/} --notes "${{ inputs.artifact-name }} | sha256 ${{ steps.checksum.outputs.sha256 }} | commit ${{ github.sha }} | verify with -- gh attestation verify ${{ inputs.artifact-name }} --repo ${GITHUB_REPOSITORY} --signer-repo stuttgart-things/github-workflow-templates" --tag ${{ inputs.tag || inputs.artifact-name }} --title "${{ inputs.tag || inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}" --files "/tmp/${{ inputs.artifact-name }}.sha256" --progress plain
           module: github.com/stuttgart-things/dagger/ansible@${{ inputs.dagger-module-version }}


### PR DESCRIPTION
Found while verifying the first real release, `sthings-baseos-26.729.1165`.

## The documented command does not work

#125 added this comment:

```
gh attestation verify <file> --repo <owner>/<repo>
```

Running it against the published artifact:

```
Error: verifying with issuer "sigstore.dev"
```

The signing identity in the certificate is **this reusable workflow**, which lives in a different repository from the artifact. Without `--signer-repo`, `gh` looks for a signer in the artifact's own repo, finds none, and emits that bare error — which reads like a **bad artifact** rather than a bad command. A consumer following the documented steps would reasonably conclude the release was not trustworthy.

The working command:

```bash
gh attestation verify sthings-baseos-26.729.1165.tar.gz \
  --repo stuttgart-things/ansible \
  --signer-repo stuttgart-things/github-workflow-templates
```

## The attestation itself is fine

Verified against the published artifact:

```
subject   : sthings-baseos-26.729.1165.tar.gz
digest    : b3a61def7ef036d588ed8a999b524e1b3949b328ba51d1b58fd13a63c685400f
predicate : https://slsa.dev/provenance/v1
builder   : .../call-release-artifact.yaml@1814f1e
sourceRepo: https://github.com/stuttgart-things/ansible
commit    : eb52831
runner    : github-hosted
```

`sha256sum -c` on the published `.sha256` also passes.

## Also in the release notes

A workflow comment is not where anyone looks when checking a download, so the command now goes into the release body next to the digest.

Note the notes string uses `verify with --` rather than `verify:`. A `': '` inside that unquoted YAML scalar is a mapping indicator and breaks the file — caught by `check-jsonschema` before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY