### PR TITLE
fix(ansible): refresh stale dagger defaults and let renovate manage them

### DIFF
--- a/.github/workflows/call-release-artifact.yaml
+++ b/.github/workflows/call-release-artifact.yaml
@@ -24,11 +24,11 @@ on:
       dagger-module-version:
         required: false
         type: string
-        default: v0.2.1
+        default: v0.121.0
       dagger-version:
         required: false
         type: string
-        default: "0.18.10"
+        default: v0.21.7
 
 jobs:
   release-artifact:

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,36 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "STUTTGART-THINGS DAGGER ANSIBLE MODULE PIN. LIVES IN SIX PLACES ACROSS TWO REPOS AND WAS ALIGNED BY HAND THREE TIMES",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "DAGGER_ANSIBLE_MODULE_VERSION:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "dagger-module-version:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "dagger-module-version:\\n(?:[ \\t]+[^\\n]*\\n)*?[ \\t]+default:[ \\t]*['\"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)['\"]?"
+      ],
+      "depNameTemplate": "stuttgart-things/dagger",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "DAGGER CLI PIN, PASSED TO dagger/dagger-for-github",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "dagger-version:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "dagger-version:\\n(?:[ \\t]+[^\\n]*\\n)*?[ \\t]+default:[ \\t]*['\"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)['\"]?"
+      ],
+      "depNameTemplate": "dagger/dagger",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
   ]
 }


### PR DESCRIPTION
Addresses finding #8 of stuttgart-things/ansible#1043.

## A stale default that nobody was watching

`call-release-artifact.yaml` declared:

```yaml
dagger-module-version:
  default: v0.2.1        # upstream: v0.121.0  (~119 releases behind)
dagger-version:
  default: "0.18.10"     # upstream: v0.21.7   (also missing the v prefix)
```

This is the same trap templates#121 fixed in `call-ansible-collection.yaml`, where the default had sat at `v0.13.0`.

Harmless **today** only because every caller passes explicit values. Called without them, this workflow silently runs a module predating both the monotonic version scheme and the tag-naming fix — so it would publish a release tagged with a *filename* and a version that can run backwards. Exactly the two bugs findings #1 and #3 were about.

## Why a Renovate manager, not just new values

These pins live in **six places across two repos**:

| repo | file |
|---|---|
| ansible | `Taskfile.yaml` |
| ansible | `pr-collection-build.yaml` |
| ansible | `main-collection-build.yaml` |
| ansible | `dispatch-collection-build.yml` |
| templates | `call-ansible-collection.yaml` |
| templates | `call-release-artifact.yaml` |

They were aligned by hand three separate times this week. Fixing the values without automating them just resets the clock.

The existing custom managers key on `_version:` and `Version:` — neither matches `dagger-module-version:` or `DAGGER_ANSIBLE_MODULE_VERSION:`. And one of the six is a `workflow_call` input default, where the key and the value are three lines apart, so it needs a multi-line match.

## Verification

Ran Renovate's own regex extractor over the real files in both repos — **11 of 11 pins found**, including the two stale ones:

```
[ansible]   Taskfile.yaml                    stuttgart-things/dagger  v0.121.0
[ansible]   pr-collection-build.yaml         stuttgart-things/dagger  v0.121.0
                                             dagger/dagger            v0.21.7
[ansible]   main-collection-build.yaml       stuttgart-things/dagger  v0.121.0
                                             dagger/dagger            v0.21.7
[ansible]   dispatch-collection-build.yml    stuttgart-things/dagger  v0.121.0
                                             dagger/dagger            v0.21.7
[templates] call-ansible-collection.yaml     stuttgart-things/dagger  v0.121.0
                                             dagger/dagger            v0.21.7
[templates] call-release-artifact.yaml       stuttgart-things/dagger  v0.2.1     <- stale
                                             dagger/dagger            0.18.10    <- stale
```

`renovate-config-validator` passes; `check-jsonschema` passes on the workflow.

The companion PR adds the same managers to the ansible repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY