### PR TITLE
fix(ansible): bump call-release-artifact pin to pick up #127 and #128

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -132,7 +132,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-artifact.yaml@1814f1e31dddaab2273396879d0ff2d4bcb05efe # main
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-artifact.yaml@e868d3fb1d0b9723904b0486a3bfe91272154036 # main
     with:
       runs-on: ${{ inputs.runs-on }}
       environment-name: k8s


### PR DESCRIPTION
Mechanical follow-up, same as #126.

`call-ansible-collection.yaml` pinned `call-release-artifact.yaml@1814f1e`, which predates both #127 (the corrected attestation verify command, now also in the release notes) and #128 (the refreshed dagger defaults).

Without this bump both would be merged and look shipped while the release path kept invoking the old workflow — so consumers would keep getting release notes carrying a verify command that fails.

Bumped to `e868d3f`, current main.

This is the second time a SHA pin has needed a deliberate follow-up commit to take effect. It is the cost of pinning, and worth remembering: **merging a change to a pinned reusable workflow does not deploy it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY