### PR TITLE
chore(dagger): pin all dagger-version defaults to v0.21.8

### DIFF
--- a/.github/workflows/call-ansible-collection.yaml
+++ b/.github/workflows/call-ansible-collection.yaml
@@ -17,7 +17,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: v0.21.7
+        default: v0.21.8
       dagger-module-version:
         required: false
         type: string

--- a/.github/workflows/call-argocd-bootstrap.yaml
+++ b/.github/workflows/call-argocd-bootstrap.yaml
@@ -191,7 +191,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       argocd-module-version:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false

--- a/.github/workflows/call-argocd-verify-catalog.yaml
+++ b/.github/workflows/call-argocd-verify-catalog.yaml
@@ -27,7 +27,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       argocd-module-version:
         description: "Version of stuttgart-things/dagger/argocd to invoke"
         required: false

--- a/.github/workflows/call-create-vault-issuer.yaml
+++ b/.github/workflows/call-create-vault-issuer.yaml
@@ -72,7 +72,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       argocd-module-version:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false

--- a/.github/workflows/call-create-vault-k8s-auth.yaml
+++ b/.github/workflows/call-create-vault-k8s-auth.yaml
@@ -62,7 +62,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       argocd-module-version:
         description: "Version of stuttgart-things/blueprints/argocd"
         required: false

--- a/.github/workflows/call-crossplane-verify.yaml
+++ b/.github/workflows/call-crossplane-verify.yaml
@@ -29,7 +29,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       crossplane-module-version:
         description: "Version of stuttgart-things/dagger/crossplane to invoke"
         required: false

--- a/.github/workflows/call-dagger-ko-build.yaml
+++ b/.github/workflows/call-dagger-ko-build.yaml
@@ -30,7 +30,7 @@ on:
         default: "github.com/stuttgart-things/dagger/go@v0.103.0"
         type: string
       dagger-version:
-        default: "0.20.6"
+        default: "0.21.8"
         type: string
       image-ref-artifact:
         default: ""

--- a/.github/workflows/call-dagger-security-scan.yaml
+++ b/.github/workflows/call-dagger-security-scan.yaml
@@ -14,7 +14,7 @@ on:
         default: "github.com/stuttgart-things/dagger/go@v0.103.0"
         type: string
       dagger-version:
-        default: "0.20.6"
+        default: "0.21.8"
         type: string
       secure-go-version:
         default: "2.24.6"

--- a/.github/workflows/call-dagger-trivy-image-scan.yaml
+++ b/.github/workflows/call-dagger-trivy-image-scan.yaml
@@ -24,7 +24,7 @@ on:
         default: "github.com/stuttgart-things/dagger/trivy@v0.103.0"
         type: string
       dagger-version:
-        default: "0.20.6"
+        default: "0.21.8"
         type: string
       artifact-name:
         default: "trivy-image-report"

--- a/.github/workflows/call-flux-bootstrap.yaml
+++ b/.github/workflows/call-flux-bootstrap.yaml
@@ -45,7 +45,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.6"
+        default: "0.21.8"
       blueprints-version:
         description: "Blueprints Dagger module version"
         required: false

--- a/.github/workflows/call-flux-check.yaml
+++ b/.github/workflows/call-flux-check.yaml
@@ -28,7 +28,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.1"
+        default: "0.21.8"
       sops-module-version:
         description: "SOPS Dagger module version"
         required: false

--- a/.github/workflows/call-flux-destroy.yaml
+++ b/.github/workflows/call-flux-destroy.yaml
@@ -38,7 +38,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.1"
+        default: "0.21.8"
       blueprints-version:
         description: "Blueprints Dagger module version"
         required: false

--- a/.github/workflows/call-go-microservice-release.yaml
+++ b/.github/workflows/call-go-microservice-release.yaml
@@ -10,7 +10,7 @@ on:
         default: k8s
         type: string
       dagger-version:
-        default: latest
+        default: v0.21.8
         type: string
       dagger-release-module:
         default: github.com/stuttgart-things/dagger/release@v0.82.1

--- a/.github/workflows/call-helm-verify.yaml
+++ b/.github/workflows/call-helm-verify.yaml
@@ -46,7 +46,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.6"
+        default: "0.21.8"
       helm-module-version:
         description: "Version of stuttgart-things/dagger/helm to invoke"
         required: false

--- a/.github/workflows/call-kcl-validate.yaml
+++ b/.github/workflows/call-kcl-validate.yaml
@@ -54,7 +54,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       kcl-module-version:
         description: "Version of stuttgart-things/dagger/kcl to invoke"
         required: false

--- a/.github/workflows/call-pre-commit.yaml
+++ b/.github/workflows/call-pre-commit.yaml
@@ -43,7 +43,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.8"
+        default: "0.21.8"
       linting-module-version:
         description: "Version of stuttgart-things/dagger/linting to invoke"
         required: false

--- a/.github/workflows/call-push-kustomize.yaml
+++ b/.github/workflows/call-push-kustomize.yaml
@@ -26,7 +26,7 @@ on:
         default: github.com/stuttgart-things/dagger/kcl@v0.114.0
         type: string
       dagger-version:
-        default: "0.20.8"
+        default: "0.21.8"
         type: string
     outputs:
       artifact-ref:

--- a/.github/workflows/call-python-validation.yaml
+++ b/.github/workflows/call-python-validation.yaml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       dagger-version:
-        default: "0.20.0"
+        default: "0.21.8"
         required: false
         type: string
       dagger-module-version:

--- a/.github/workflows/call-release-artifact.yaml
+++ b/.github/workflows/call-release-artifact.yaml
@@ -28,7 +28,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: v0.21.7
+        default: v0.21.8
 
 jobs:
   release-artifact:

--- a/.github/workflows/call-repository-linting.yaml
+++ b/.github/workflows/call-repository-linting.yaml
@@ -26,7 +26,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: "0.19.3"
+        default: "0.21.8"
       dagger-module-version:
         required: false
         type: string

--- a/.github/workflows/call-terraform-vault.yaml
+++ b/.github/workflows/call-terraform-vault.yaml
@@ -44,7 +44,7 @@ on:
       dagger-version:
         required: false
         type: string
-        default: "0.20.6"
+        default: "0.21.8"
       blueprints-version:
         required: false
         type: string

--- a/.github/workflows/call-validate-json-schema.yaml
+++ b/.github/workflows/call-validate-json-schema.yaml
@@ -25,7 +25,7 @@ on:
         description: "Dagger CLI version"
         required: false
         type: string
-        default: "0.20.6"
+        default: "0.21.8"
       linting-module-version:
         description: "Version of stuttgart-things/dagger/linting to invoke"
         required: false

--- a/.github/workflows/this-lint-repo.yaml
+++ b/.github/workflows/this-lint-repo.yaml
@@ -21,7 +21,7 @@ jobs:
       app-directory: "./"
       output-file: "/tmp/github-workflow-templates-findings.txt"
       continue-error: "true"
-      dagger-version: v0.19.3
+      dagger-version: v0.21.8
       dagger-module-version: v1.17.0
       branch-name: ${{ github.head_ref || github.ref_name }}
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## What

Bumps the `dagger-version` default to **`v0.21.8`** across every reusable workflow (and the `this-lint-repo` caller), consolidating the previously scattered pins onto a single current version.

## Why

The dagger CLI version was pinned inconsistently across workflows (`0.19.x`, `0.20.x`, `0.21.7`, and a floating `latest`). Standardizing on `0.21.8` keeps all callers on the same, current dagger CLI and lets Renovate manage the pins going forward.

## Changes

23 files updated — `dagger-version` default set to `0.21.8`:

- `0.19.3` → `call-repository-linting`, `this-lint-repo`
- `0.20.0` → `call-python-validation`
- `0.20.1` → `call-flux-destroy`, `call-flux-check`
- `0.20.6` → `call-terraform-vault`, `call-validate-json-schema`, `call-helm-verify`, `call-dagger-security-scan`, `call-dagger-trivy-image-scan`, `call-dagger-ko-build`, `call-flux-bootstrap`
- `0.20.8` → `call-argocd-bootstrap`, `call-kcl-validate`, `call-create-vault-k8s-auth`, `call-argocd-verify-catalog`, `call-push-kustomize`, `call-crossplane-verify`, `call-create-vault-issuer`, `call-pre-commit`
- `v0.21.7` → `call-release-artifact`, `call-ansible-collection`
- `latest` → `call-go-microservice-release` (now pinned)

Each file's existing quoting / `v`-prefix style is preserved. Files with no dagger CLI pin (`call-stage-image`, `call-ko-build`, `call-terraform-docs`) are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8h6K4f2puVKHdo2eBFEa6)_